### PR TITLE
Fix inability to replace devices with auton bay

### DIFF
--- a/Transcendence/TransCore/RPGCode.xml
+++ b/Transcendence/TransCore/RPGCode.xml
@@ -1675,7 +1675,7 @@
 
 					;	If the target object is not the player's ship, then we need to modify
 					;	some text
-					(textYourShip (if (= targetObj gPlayerShip) "your ship" (cat "the " (objGetName targetObj 0x00))))
+					(textYourShip (if (= targetObj gPlayerShip) "your ship" (objGetName targetObj 'demonstrative)))
 					(textWe (if (= installerObj gPlayerShip) "you" "we"))
 					(textYour (if (= targetObj gPlayerShip) "your" "the"))
 					)
@@ -1705,7 +1705,6 @@
 								)
 							cargoNeeded resultMessage resultCode returnValue stationCannotInstall removeStatus
 							installText installTextData
-							stationRemoveStatus
 							militaryCheck
 							)
 
@@ -1730,7 +1729,7 @@
 										))
 										
 								;	If the installer is the player ship, and it doesn't define
-								;	and installation limits, then just allow everything. (This means
+								;	any installation limits, then just allow everything. (This means
 								;	that callers are responsible for setting limits. E.g., the Auton
 								;	Bay handles this.)
 								
@@ -1925,7 +1924,7 @@
 										(setq desc (or
 											(objTranslate installerObj 'rpg.installDeviceAfterRemove { item:thisItem targetObj:targetObj itemToReplace:itemToReplace })
 											(scrTranslate gScreen 'rpg.installDeviceAfterRemove { item:thisItem targetObj:targetObj itemToReplace:itemToReplace })
-											(cat (strCapitalize textWe) " can remove " textYour " " (itmGetName itemToReplace 0x80) " and install " itemName)
+											(cat (strCapitalize textWe) " can remove " textYour " " (itmGetName itemToReplace 'short) " and install " itemName)
 											))
 										(setq installText 'rpg.installDeviceAfterRemove)
 										(setq installTextData { item:thisItem targetObj:targetObj itemToReplace:itemToReplace })
@@ -1982,26 +1981,76 @@
 									(setq desc (or
 										(objTranslate installerObj 'rpg.cannotInstallDeviceBecauseCannotRemove { item:thisItem targetObj:targetObj itemToReplace:itemToReplace removeStatus:removeStatus })
 										(scrTranslate gScreen 'rpg.cannotInstallDeviceBecauseCannotRemove { item:thisItem targetObj:targetObj itemToReplace:itemToReplace removeStatus:removeStatus })
-										(cat desc ". " (if (isint removeStatus) "Unfortunately, you cannot remove the device." removeStatus))
+										(cat (strCapitalize textWe) " can install " itemName ". "
+											(if (isInt removeStatus)
+												(cat "Unfortunately, " textYour " " (itmGetName itemToReplace 'short) " cannot be removed.")
+												removeStatus
+												)
+											)
 										))
 									(setq canInstall Nil)
 									)
 								)
 
 							; See if the station can remove the device
-
-							(if (and canInstall itemToReplace
-									(setq stationRemoveStatus (objGetItemProperty installerObj itemToReplace 'removeItemStatus))
-									(not (@ stationRemoveStatus 'canRemove))
+							
+							(if (and canInstall itemToReplace)
+								(block (
+									(stationRemoveStatus (objGetItemProperty installerObj itemToReplace 'removeItemStatus))
+									stationCannotRemove
 									)
-								(block ()
-									(setq desc
-										(cat desc ". Unfortunately, we cannot remove your " (itmGetName itemToReplace 'short))
+									(switch
+										; If tech criteria provided then use them for check
+										
+										(or (@ data 'maxTechLevel) (@ data 'techCriteria))
+											(setq stationCannotRemove (or
+												;	If we don't match the tech criteria then we don't have the
+												;	technology to remove.
+												(and (@ data 'techCriteria) (not (itmMatches itemToReplace (@ data 'techCriteria))))
+
+												;	If our max tech level is too low for the item, then we can't remove
+												;	(except for specific items that we know about)
+												(and (gr (itmGetLevel itemToReplace) (or (@ data 'maxTechLevel) 30))
+													(or (not (@ data 'techCriteriaOverride))
+														(not (itmMatches itemToReplace (@ data 'techCriteriaOverride)))
+														)
+													)
+												))
+												
+										;	If the installer is the player ship, and it doesn't define
+										;	any removal limits, then just allow everything. (This means
+										;	that callers are responsible for setting limits.)
+										
+										(and (= installerObj gPlayerShip) (not (objGetProperty installerObj 'removeDeviceMaxLevel)))
+											(setq stationCannotRemove Nil)
+											
+										;	If we have totalPrice or installPriceAdj AND we're a previous version, then
+										;	we always allow removal (even if no TradeDesc). We (might?) need this for backwards
+										;	compatibility.
+										
+										(and (ls (getAPIVersion) 31)
+												(or (@ data 'totalPrice) (@ data 'installPriceAdj))
+												)
+											(block Nil
+												;(dbgOutput "API: " (getAPIVersion))
+												(setq stationCannotRemove Nil)
+												)
+
+										;	Otherwise result depends on removeItemStatus property
+										(setq stationCannotRemove (not (@ stationRemoveStatus 'canRemove)))
 										)
-									(setq canInstall Nil)
+										
+									(if stationCannotRemove
+										(block ()
+											(setq desc
+												(cat (strCapitalize textWe) " can install " itemName ". Unfortunately, " textWe " cannot remove " textYour " " (itmGetName itemToReplace 'short) ".")
+												)
+											(setq canInstall Nil)
+											)
+										)
 									)
 								)
-
+							
 							; See if the item fits
 
 							(if (and canInstall


### PR DESCRIPTION
This changes rpgInstallDevicePrep so that replacing devices uses the same rules as installing them. So if the player is the installer and no tech criteria or max levels are specified, they can remove anything.

Also some minor language improvements.

https://ministry.kronosaur.com/record.hexm?id=84089