### PR TITLE
Fix drawing of capacitor counters when 2+ devices are charging.

### DIFF
--- a/Transcendence/Transcendence/CDeviceCounterDisplay.cpp
+++ b/Transcendence/Transcendence/CDeviceCounterDisplay.cpp
@@ -99,7 +99,7 @@ void CDeviceCounterDisplay::PaintDevice (CInstalledDevice *pDevice, int x)
 	//	Figure out title and level colors
 
 	CDeviceClass::CounterTypes iType;
-	int iLevel = pDevice->GetCounter(pShip, &iType);
+	int iLevel = Max(0, pDevice->GetCounter(pShip, &iType));
 
 	CString sTitle;
     CG32bitPixel rgbLevelColor;


### PR DESCRIPTION
Previously, a negative charge on the right-most device would draw on top
of the charge for the device immediately to the left.