### PR TITLE
Added NoFireWhileBlind property to weapons (port of #65 from old Mammoth codebase)

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -836,6 +836,7 @@ class CWeaponClass : public CDeviceClass
 		int m_iCounterPerShot;					//	How much to increment the ship's counter by per shot
 		bool m_bOmnidirectional;				//	Omnidirectional
 		bool m_bMIRV;							//	Each shot seeks an independent target
+		bool m_bNoFireWhenBlind;				//	Disallow firing this weapon if blinded
 		bool m_bReportAmmo;						//	Report count of ammo shot even if not a launcher
 		int m_iMinFireArc;						//	Min angle of fire arc (degrees)
 		int m_iMaxFireArc;						//	Max angle of fire arc (degrees)

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -836,7 +836,7 @@ class CWeaponClass : public CDeviceClass
 		int m_iCounterPerShot;					//	How much to increment the ship's counter by per shot
 		bool m_bOmnidirectional;				//	Omnidirectional
 		bool m_bMIRV;							//	Each shot seeks an independent target
-		bool m_bNoFireWhenBlind;				//	Disallow firing this weapon if blinded
+		bool m_bCanFireWhenBlind;				//	Allow firing this weapon if blinded
 		bool m_bReportAmmo;						//	Report count of ammo shot even if not a launcher
 		int m_iMinFireArc;						//	Min angle of fire arc (degrees)
 		int m_iMaxFireArc;						//	Max angle of fire arc (degrees)


### PR DESCRIPTION
This attribute prevents firing the specified weapon when blinded e.g. by a blinder cannon or damaged visual display ROM. This could be used to give blinding weapons some use against AI ships, by preventing the AI ships (and the player) from using certain weapons (e.g. homing missiles) if blinded.