### PR TITLE
Fix 3DConversion + ZPos.

### DIFF
--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -189,11 +189,13 @@ ALERROR C3DConversion::Init (CXMLElement *pDesc)
 
 	{
 	C3DObjectPos Pos;
+	bool b3DPos;
 
-	Pos.InitFromXML(pDesc, C3DObjectPos::FLAG_CALC_POLAR, &m_bUseCompatible);
+	Pos.InitFromXML(pDesc, C3DObjectPos::FLAG_CALC_POLAR, &b3DPos);
 	m_iAngle = Pos.GetAngle();
 	m_iRadius = Pos.GetRadius();
 	m_iZ = Pos.GetZ();
+	m_bUseCompatible = !b3DPos;
 		
 	//	Read the sendToBack and bringToFront attributes
 


### PR DESCRIPTION
Previously the compatibility mode was switched on when Z was specified,
rather than the reverse.