### PR TITLE
Implement configurable shot separation scale.

### DIFF
--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -639,7 +639,7 @@ class CInstalledDevice
 		int m_iMinFireArc:16;					//	Min angle of fire arc (degrees)
 		int m_iMaxFireArc:16;					//	Max angle of fire arc (degrees)
 
-		unsigned int m_iShotSeparationScale:16;	//	Out of 32767. Governs scaling of shot separation for dual etc weapons
+		int m_iShotSeparationScale:16;			//	Scaled by 32767. Governs scaling of shot separation for dual etc weapons
 		DWORD m_dwSpare1:16;
 
 		int m_iTimeUntilReady:16;				//	Timer counting down until ready to activate

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -385,6 +385,7 @@ struct SDeviceDesc
 
 	CEnhancementDesc Enhancements;				//	Slot enhancements to installed device
 	int iSlotBonus = 0;
+	double rShotSeparationScale = 1.;			//	Governs scaling of shot separation for dual etc weapons
 	};
 
 class CDeviceDescList
@@ -490,6 +491,7 @@ class CInstalledDevice
 		inline int GetPosZ (void) const { return m_iPosZ; }
 		inline int GetRotation (void) const { return AngleMiddle(m_iMinFireArc, m_iMaxFireArc); }
 		inline const CEnhancementDesc &GetSlotEnhancements (void) const { return m_SlotEnhancements; }
+		inline double GetShotSeparationScale(void) const { return (double)m_iShotSeparationScale / 32767.0; }
 		inline int GetSlotPosIndex (void) const { return m_iSlotPosIndex; }
 		inline int GetTemperature (void) const { return m_iTemperature; }
 		inline int GetTimeUntilReady (void) const { return m_iTimeUntilReady; }
@@ -637,6 +639,9 @@ class CInstalledDevice
 		int m_iMinFireArc:16;					//	Min angle of fire arc (degrees)
 		int m_iMaxFireArc:16;					//	Max angle of fire arc (degrees)
 
+		unsigned int m_iShotSeparationScale:16;	//	Out of 32767. Governs scaling of shot separation for dual etc weapons
+		DWORD m_dwSpare1:16;
+
 		int m_iTimeUntilReady:16;				//	Timer counting down until ready to activate
 		int m_iFireAngle:16;					//	Last fire angle
 
@@ -672,5 +677,5 @@ class CInstalledDevice
 		DWORD m_fSpare7:1;
 		DWORD m_fSpare8:1;
 
-		DWORD m_dwSpare:8;
+		DWORD m_dwSpare2:8;
 	};

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -533,6 +533,7 @@ class CInstalledDevice
 		inline void SetPosZ (int iZ) { m_iPosZ = iZ; m_f3DPosition = (iZ != 0); }
 		bool SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, CString *retsError);
 		inline void SetRegenerating (bool bRegenerating) { m_fRegenerating = bRegenerating; }
+		inline void SetShotSeparationScale(double rShotSeparationScale) { m_iShotSeparationScale = (int)(rShotSeparationScale * 32767.0); }
 		inline void SetSecondary (bool bSecondary = true) { m_fSecondaryWeapon = bSecondary; }
 		inline void SetSlotPosIndex (int iIndex) { m_iSlotPosIndex = iIndex; }
 		inline void SetTemperature (int iTemperature) { m_iTemperature = iTemperature; }

--- a/Mammoth/Include/TSEVersions.h
+++ b/Mammoth/Include/TSEVersions.h
@@ -7,7 +7,7 @@
 
 constexpr DWORD API_VERSION =							44;
 constexpr DWORD UNIVERSE_SAVE_VERSION =					35;
-constexpr DWORD SYSTEM_SAVE_VERSION =					171;
+constexpr DWORD SYSTEM_SAVE_VERSION =					172;
 
 //	Uncomment out the following define when building a stable release
 
@@ -625,3 +625,6 @@ constexpr DWORD SYSTEM_SAVE_VERSION =					171;
 //
 //	171: 1.8 Beta 5
 //		Added m_sNode to CTimedMissionEvent
+//
+//	172: 1.8 Beta 5
+//		Added m_iShotSeparationScale to CInstalledDevice.

--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -840,6 +840,7 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'canBeDisrupted\n"
 			"   'external\n"
 			"   'power\n"
+			"   'shotSeparationScale\n"
 			"\n"
 			"property (weapon)\n\n"
 			"   'ammoTypes\n"
@@ -1021,6 +1022,7 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'incCharges charges\n"
 			"   'installed [True|Nil]"
 			"   'level level",
+			"   'shotSeparationScale separation\n"
 
 			"vs*",	0,	},
 

--- a/Mammoth/TSE/CDeviceTable.cpp
+++ b/Mammoth/TSE/CDeviceTable.cpp
@@ -42,6 +42,7 @@
 #define MIN_FIRE_ARC_ATTRIB						CONSTLIT("minFireArc")
 #define OMNIDIRECTIONAL_ATTRIB					CONSTLIT("omnidirectional")
 #define SECONDARY_WEAPON_ATTRIB					CONSTLIT("secondaryWeapon")
+#define SHOT_SEPARATION_SCALE_ATTRIB			CONSTLIT("shotSeparationScale")
 #define SLOT_ID_ATTRIB							CONSTLIT("slotID")
 #define TABLE_ATTRIB							CONSTLIT("table")
 #define UNID_ATTRIB								CONSTLIT("unid")
@@ -104,6 +105,8 @@ class CSingleDevice : public IDeviceGenerator
 		CEnhancementDesc m_Enhancements;		//	This slot enhances the installed device
 		int m_iSlotBonus = 0;					//	HP bonus to devices in this slot
 		bool m_bDefaultSlotBonus = false;		//	This slot does not define a bonus
+		double m_rShotSeparationScale = 1.;		//	Governs scaling of shot separation for dual etc weapons
+
 	};
 
 class CLevelTableOfDeviceGenerators : public IDeviceGenerator
@@ -263,6 +266,8 @@ ALERROR IDeviceGenerator::InitDeviceDescFromXML (SDesignLoadCtx &Ctx, CXMLElemen
 		retDesc->b3DPosition = false;
 		}
 
+	retDesc->rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, 0.0, 1.0, 1.0);
+
 	retDesc->bExternal = pDesc->GetAttributeBool(EXTERNAL_ATTRIB);
 	retDesc->bCannotBeEmpty = pDesc->GetAttributeBool(CANNOT_BE_EMPTY_ATTRIB);
 	retDesc->bOmnidirectional = pDesc->GetAttributeBool(OMNIDIRECTIONAL_ATTRIB);
@@ -395,6 +400,11 @@ void CSingleDevice::AddDevices (SDeviceGenerateCtx &Ctx)
 			Desc.iPosZ = SlotDesc.iPosZ;
 			Desc.b3DPosition = SlotDesc.b3DPosition;
 			}
+
+		if (bUseSlotDesc)
+			Desc.rShotSeparationScale = SlotDesc.rShotSeparationScale;
+		else
+			Desc.rShotSeparationScale = m_rShotSeparationScale;
 
 		//	External
 
@@ -619,6 +629,8 @@ ALERROR CSingleDevice::LoadFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc)
 		m_b3DPosition = false;
 		m_bDefaultPos = true;
 		}
+
+	m_rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, 0.0, 1.0, 1.0);
 
 	//	Load fire arc attributes
 

--- a/Mammoth/TSE/CDeviceTable.cpp
+++ b/Mammoth/TSE/CDeviceTable.cpp
@@ -266,7 +266,7 @@ ALERROR IDeviceGenerator::InitDeviceDescFromXML (SDesignLoadCtx &Ctx, CXMLElemen
 		retDesc->b3DPosition = false;
 		}
 
-	retDesc->rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, 0.0, 1.0, 1.0);
+	retDesc->rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, -1.0, 1.0, 1.0);
 
 	retDesc->bExternal = pDesc->GetAttributeBool(EXTERNAL_ATTRIB);
 	retDesc->bCannotBeEmpty = pDesc->GetAttributeBool(CANNOT_BE_EMPTY_ATTRIB);
@@ -630,7 +630,7 @@ ALERROR CSingleDevice::LoadFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc)
 		m_bDefaultPos = true;
 		}
 
-	m_rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, 0.0, 1.0, 1.0);
+	m_rShotSeparationScale = pDesc->GetAttributeDoubleBounded(SHOT_SEPARATION_SCALE_ATTRIB, -1.0, 1.0, 1.0);
 
 	//	Load fire arc attributes
 

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -19,6 +19,7 @@
 #define PROPERTY_POS							CONSTLIT("pos")
 #define PROPERTY_SECONDARY						CONSTLIT("secondary")
 #define PROPERTY_TEMPERATURE      				CONSTLIT("temperature")
+#define PROPERTY_SHOT_SEPARATION_SCALE			CONSTLIT("shotSeparationScale")
 
 //	CInstalledDevice class
 
@@ -1125,6 +1126,11 @@ bool CInstalledDevice::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem
             return false;
             }
         }
+	else if (strEquals(sName, PROPERTY_SHOT_SEPARATION_SCALE))
+		{
+		double rShotSeparationScale = Clamp(pValue->GetDoubleValue(), -1.0, 1.0);
+		SetShotSeparationScale(rShotSeparationScale);
+		}
 
 	//	Otherwise, let any sub-classes handle it.
 

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -32,6 +32,7 @@ CInstalledDevice::CInstalledDevice (void) :
 		m_iPosZ(0),
 		m_iMinFireArc(0),
 		m_iMaxFireArc(0),
+		m_iShotSeparationScale(32767),
 
 		m_iTimeUntilReady(0),
 		m_iFireAngle(0),
@@ -315,6 +316,7 @@ void CInstalledDevice::InitFromDesc (const SDeviceDesc &Desc)
 	m_iPosZ = Desc.iPosZ;
 	m_fExternal = Desc.bExternal;
 	m_fCannotBeEmpty = Desc.bCannotBeEmpty;
+	m_iShotSeparationScale = (unsigned int)(Desc.rShotSeparationScale * 32767);
 
 	SetLinkedFireOptions(Desc.dwLinkedFireOptions);
 	SetFate(Desc.iFate);
@@ -424,6 +426,7 @@ void CInstalledDevice::Install (CSpaceObject *pObj, CItemListManipulator &ItemLi
 		m_iPosZ = Desc.iPosZ;
 		m_f3DPosition = Desc.b3DPosition;
 		m_fCannotBeEmpty = Desc.bCannotBeEmpty;
+		m_iShotSeparationScale = (unsigned int)(Desc.rShotSeparationScale * 32767);
 
 		SetFate(Desc.iFate);
 
@@ -596,6 +599,7 @@ void CInstalledDevice::ReadFromStream (CSpaceObject *pSource, SLoadCtx &Ctx)
 //	DWORD		device: low = m_iSlotPosIndex; hi = m_iTemperature
 //	DWORD		device: low = m_iSlotBonus; hi = m_iDeviceSlot
 //	DWORD		device: low = m_iActivateDelay; hi = m_iPosZ
+//	DWORD		device: low = m_iShotSeparationScale; hi = UNUSED
 //	DWORD		device: flags
 //
 //	CItemEnhancementStack
@@ -712,6 +716,16 @@ void CInstalledDevice::ReadFromStream (CSpaceObject *pSource, SLoadCtx &Ctx)
 		{
 		CItemEnhancement Dummy;
 		Dummy.ReadFromStream(Ctx);
+		}
+
+	if (Ctx.dwVersion >= 172)
+		{
+		Ctx.pStream->Read((char *)&dwLoad, sizeof(DWORD));
+		m_iShotSeparationScale = (int)LOWORD(dwLoad);
+		}
+	else
+		{
+		m_iShotSeparationScale = 32767;
 		}
 
 	Ctx.pStream->Read((char *)&dwLoad, sizeof(DWORD));
@@ -1242,6 +1256,7 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 //	DWORD		device: low = m_iSlotIndex; hi = m_iTemperature
 //	DWORD		device: low = m_iSlotBonus; hi = m_iDeviceSlot
 //	DWORD		device: low = m_iActivateDelay; hi = m_iPosZ
+//	DWORD		device: low = m_iShotSeparationScale; hi = UNUSED
 //	DWORD		device: flags
 //
 //	CItemEnhancementStack
@@ -1282,6 +1297,9 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	dwSave = MAKELONG(m_iActivateDelay, m_iPosZ);
+	pStream->Write((char *)&dwSave, sizeof(DWORD));
+
+	dwSave = MAKELONG(m_iShotSeparationScale, 0);
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	dwSave = 0;

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -667,6 +667,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 	int i;
 	CSpaceObject *pSource = ItemCtx.GetSource();
 	CInstalledDevice *pDevice = ItemCtx.GetDevice();
+	double rShotSeparationScale = pDevice->GetShotSeparationScale();
 
 	//	Compute the source position
 
@@ -689,7 +690,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 			//	Compute a normal perpendicular to the direction of fire
 
 			CVector Perp = PolarToVector(iFireAngle, (g_KlicksPerPixel * g_DualShotSeparation));
-			Perp = Perp.Perpendicular();
+			Perp = Perp.Perpendicular() * rShotSeparationScale;
 
 			//	Create two shots
 
@@ -708,7 +709,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 			//	Compute a normal perpendicular to the direction of fire
 
 			CVector Perp = PolarToVector(iFireAngle, (g_KlicksPerPixel * g_DualShotSeparation));
-			Perp = Perp.Perpendicular();
+			Perp = Perp.Perpendicular() * rShotSeparationScale;
 
 			//	If we have a device, the alternate
 
@@ -748,7 +749,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 			//	Compute a normal perpendicular to the direction of fire
 
 			CVector Perp = PolarToVector(iFireAngle, (g_KlicksPerPixel * g_DualShotSeparation));
-			Perp = Perp.Perpendicular();
+			Perp = Perp.Perpendicular() * rShotSeparationScale;
 
 			//	Create five shots
 
@@ -813,7 +814,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 				int iShot = Max(0, Min(GetAlternatingPos(pDevice), m_iConfigCount));
 
 				iShotCount = 1;
-				ShotPos[0] = vSource + PolarToVector(AngleMod(iFireAngle + m_pConfig[iShot].iPosAngle), m_pConfig[iShot].rPosRadius);
+				ShotPos[0] = vSource + PolarToVector(AngleMod(iFireAngle + m_pConfig[iShot].iPosAngle), m_pConfig[iShot].rPosRadius) * rShotSeparationScale;
 				ShotDir[0] = AngleMod(iFireAngle + m_pConfig[iShot].Angle.Roll());
 
 				//	Next shot in sequence
@@ -827,7 +828,7 @@ int CWeaponClass::CalcConfiguration (CItemCtx &ItemCtx, CWeaponFireDesc *pShot, 
 
 				for (i = 0; i < iShotCount; i++)
 					{
-					ShotPos[i] = vSource + PolarToVector(AngleMod(iFireAngle + m_pConfig[i].iPosAngle), m_pConfig[i].rPosRadius);
+					ShotPos[i] = vSource + PolarToVector(AngleMod(iFireAngle + m_pConfig[i].iPosAngle), m_pConfig[i].rPosRadius) * rShotSeparationScale;
 					ShotDir[i] = AngleMod(iFireAngle + m_pConfig[i].Angle.Roll());
 					}
 				}

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -51,6 +51,7 @@
 #define PROPERTY_SECONDARY						CONSTLIT("secondary")
 #define PROPERTY_SLOT_ID						CONSTLIT("slotID")
 #define PROPERTY_TEMPERATURE      				CONSTLIT("temperature")
+#define PROPERTY_SHOT_SEPARATION_SCALE			CONSTLIT("shotSeparationScale")
 
 const int MAX_COUNTER =					        100;
 
@@ -550,6 +551,11 @@ ICCItem *CDeviceClass::FindItemProperty (CItemCtx &Ctx, const CString &sName)
 
         return CC.CreateInteger(iLevel);
         }
+
+	else if (strEquals(sName, PROPERTY_SHOT_SEPARATION_SCALE))
+		{
+		return (pDevice ? CC.CreateDouble(pDevice->GetShotSeparationScale()) : CC.CreateNil());
+		}
 
     else
         return NULL;


### PR DESCRIPTION
See http://ministry.kronosaur.com/record.hexm?id=84395 for a discussion.

This can obviously wait after 1.8 release :).

Here are some more of my thoughts about the implementation strategy. I ended up scaling everything, and not just the perpendicular direction because I think the in-universe explanation for this factor is that it is a display correction, not an actual property of the weapon. I.e. the item graphics display the weapons as dual-barrel etc assemblies with a fixed separation, so what this approximates is that the same weapon appears smaller (and thus has closer-spaced shots) on certain ships. Custom configurations to me represent some custom variety of that, and thus are scaled uniformly as well.