### PR TITLE
Fixed 'Insufficient arguments' error with itmSetProperty.

### DIFF
--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -1022,8 +1022,8 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'disrupted [True|Nil|ticks]\n"
 			"   'incCharges charges\n"
 			"   'installed [True|Nil]"
-			"   'level level",
-			"   'shotSeparationScale separation\n"
+			"   'level level"
+			"   'shotSeparationScale separation\n",
 
 			"vs*",	0,	},
 


### PR DESCRIPTION
`itmSetProperty` will always give "Insufficient arguments" when run due to an improperly placed comma. I've relocated the comma to the correct location (after the help string).