### PR TITLE
Added new linked fire options: "whenSelected", "whenSelectedSameVariant" and "neverFire"

### DIFF
--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -160,7 +160,8 @@ class CDeviceClass
 			lkfTargetInRange =		0x0000002,	//	Fire only if the target is in range
 			lkfEnemyInRange =		0x0000004,	//	Fire only an enemy is in range
 			lkfSelected =			0x0000008,  //  All weapons of this type selectable for linked fire by player
-			lkfNever =				0x0000010,  //  Never fire this weapon
+			lkfSelectedVariant =	0x0000010,	//  As above, but applies on combinations of type AND variant, rather than all of a given type regardless of variant
+			lkfNever =				0x0000020,  //  Never fire this weapon
 			};
 
 		enum ECachedHandlers
@@ -681,8 +682,8 @@ class CInstalledDevice
 		DWORD m_fFateComponetized:1;			//	Always break into components when ship destroyed
 		DWORD m_fLinkedFireSelected : 1;		//	If TRUE, lkfSelected
 		DWORD m_fLinkedFireNever : 1;			//	If TRUE, lkfNever
+		DWORD m_fLinkedFireSelectedVariants : 1;//  If TRUE, lkfSelectedVariant
 		DWORD m_fCycleFire :1;					//	If TRUE, then cycle fire through weapons of same type and linked fire settings
-		DWORD m_fSpare8:1;
 
 		DWORD m_dwSpare2:8;
 	};

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -475,6 +475,7 @@ class CInstalledDevice
 
 		inline bool CanBeEmpty (void) const { return !m_fCannotBeEmpty; }
 		inline int GetCharges (CSpaceObject *pSource) { return (m_pItem ? m_pItem->GetCharges() : 0); }
+		inline bool GetCycleFireSettings (void) const { return m_fCycleFire; }
 		inline DWORD GetData (void) const { return m_dwData; }
 		inline int GetDeviceSlot (void) const { return m_iDeviceSlot; }
 		inline TSharedPtr<CItemEnhancementStack> GetEnhancementStack (void) const { return m_pEnhancements; }
@@ -516,6 +517,7 @@ class CInstalledDevice
 		inline bool IsWorking (void) const { return (IsEnabled() && !IsDamaged() && !IsDisrupted()); }
 		inline bool IsWaiting (void) const { return (m_fWaiting ? true : false); }
 		inline void SetActivateDelay (int iDelay) { m_iActivateDelay = iDelay; }
+		inline void SetCycleFireSettings (bool bCycleFire) { m_fCycleFire = bCycleFire; }
 		inline void SetData (DWORD dwData) { m_dwData = dwData; }
 		inline void SetDeviceSlot (int iDev) { m_iDeviceSlot = iDev; }
 		inline void SetDuplicate (bool bDuplicate = true) { m_fDuplicate = bDuplicate; }
@@ -679,7 +681,7 @@ class CInstalledDevice
 		DWORD m_fFateComponetized:1;			//	Always break into components when ship destroyed
 		DWORD m_fLinkedFireSelected : 1;		//	If TRUE, lkfSelected
 		DWORD m_fLinkedFireNever : 1;			//	If TRUE, lkfNever
-		DWORD m_fSpare7:1;
+		DWORD m_fCycleFire :1;					//	If TRUE, then cycle fire through weapons of same type and linked fire settings
 		DWORD m_fSpare8:1;
 
 		DWORD m_dwSpare2:8;

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -159,6 +159,8 @@ class CDeviceClass
 			lkfAlways =				0x0000001,	//	Linked to fire button
 			lkfTargetInRange =		0x0000002,	//	Fire only if the target is in range
 			lkfEnemyInRange =		0x0000004,	//	Fire only an enemy is in range
+			lkfSelected =			0x0000008,  //  All weapons of this type selectable for linked fire by player
+			lkfNever =				0x0000010,  //  Never fire this weapon
 			};
 
 		enum ECachedHandlers
@@ -675,8 +677,8 @@ class CInstalledDevice
 		DWORD m_fFateDamaged:1;					//	Always damaged when ship destroyed
 		DWORD m_fFateDestroyed:1;				//	Always destroyed when ship destroyed
 		DWORD m_fFateComponetized:1;			//	Always break into components when ship destroyed
-		DWORD m_fSpare5:1;
-		DWORD m_fSpare6:1;
+		DWORD m_fLinkedFireSelected : 1;		//	If TRUE, lkfSelected
+		DWORD m_fLinkedFireNever : 1;			//	If TRUE, lkfNever
 		DWORD m_fSpare7:1;
 		DWORD m_fSpare8:1;
 

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -102,7 +102,7 @@ class CDeviceSystem
 
 		int FindFreeSlot (void);
 		int FindNamedIndex (const CItem &Item) const;
-		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1) const;
+		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false) const;
 		int FindRandomIndex (bool bEnabledOnly) const;
 		bool FindWeaponByItem (const CItem &Item, int *retiIndex = NULL, int *retiVariant = NULL) const;
 		inline int GetCount (void) const { return m_Devices.GetCount(); }

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -102,7 +102,7 @@ class CDeviceSystem
 
 		int FindFreeSlot (void);
 		int FindNamedIndex (const CItem &Item) const;
-		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false, bool selectedFireVariants = false) const;
+		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false) const;
 		int FindRandomIndex (bool bEnabledOnly) const;
 		bool FindWeaponByItem (const CItem &Item, int *retiIndex = NULL, int *retiVariant = NULL) const;
 		inline int GetCount (void) const { return m_Devices.GetCount(); }

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -102,7 +102,7 @@ class CDeviceSystem
 
 		int FindFreeSlot (void);
 		int FindNamedIndex (const CItem &Item) const;
-		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false) const;
+		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false, bool selectedFireVariants = false) const;
 		int FindRandomIndex (bool bEnabledOnly) const;
 		bool FindWeaponByItem (const CItem &Item, int *retiIndex = NULL, int *retiVariant = NULL) const;
 		inline int GetCount (void) const { return m_Devices.GetCount(); }

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -984,6 +984,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		void DisableAllDevices (void);
 		void EnableDevice (int iDev, bool bEnable = true, bool bSilent = false);
 		bool FindDeviceAtPos (const CVector &vPos, CInstalledDevice **retpDevice);
+		int GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice);
 		DeviceNames GetDeviceNameForCategory (ItemCategories iCategory);
 		int GetItemDeviceName (const CItem &Item) const;
 		CItem GetNamedDeviceItem (DeviceNames iDev);

--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -2216,7 +2216,8 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'incCharges charges\n"
 			"   'linkedFireOptions list-of-options\n"
 			"   'pos (angle radius [z])\n"
-			"   'secondary [True|Nil]",
+			"   'secondary [True|Nil]"
+			"   'cycleFire [True|Nil]",
 
 			"ivs*",	PPFLAG_SIDEEFFECTS,	},
 

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -255,7 +255,7 @@ int CDeviceSystem::FindNamedIndex (const CItem &Item) const
 	return -1;
 	}
 
-int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir) const
+int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons) const
 
 //	FindNextIndex
 //
@@ -278,13 +278,16 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 	//  Only return a "fire if selected" device if it is the FIRST such weapon of a given type.
 
 	TSortMap<DWORD, int> FireWhenSelectedDeviceTypes;
-	for (int i = 0; i < GetCount(); i++)
+	if (switchWeapons)
 		{
-		if (!m_Devices[i].IsEmpty()
-			&& m_Devices[i].GetCategory() == Category
-			&& m_Devices[i].GetLinkedFireOptions() == CDeviceClass::lkfSelected
-			&& !FireWhenSelectedDeviceTypes.Find(m_Devices[i].GetUNID()))
-			FireWhenSelectedDeviceTypes.Insert(m_Devices[i].GetUNID(), i);
+		for (int i = 0; i < GetCount(); i++)
+			{
+			if (!m_Devices[i].IsEmpty()
+				&& m_Devices[i].GetCategory() == Category
+				&& m_Devices[i].GetLinkedFireOptions() == CDeviceClass::lkfSelected
+				&& !FireWhenSelectedDeviceTypes.Find(m_Devices[i].GetUNID()))
+				FireWhenSelectedDeviceTypes.Insert(m_Devices[i].GetUNID(), i);
+			}
 		}
 
 	for (int i = 0; i < GetCount(); i++)
@@ -295,8 +298,8 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 		if (!m_Devices[iDevice].IsEmpty() 
 				&& m_Devices[iDevice].GetCategory() == Category
 				&& m_Devices[iDevice].IsSelectable(CItemCtx(pObj, &m_Devices[iDevice]))
-				&& (m_Devices[iDevice].GetLinkedFireOptions() == CDeviceClass::lkfSelected ?
-					iDevice == iEarliestLkfSelectedItem : true))
+				&& (switchWeapons ? (m_Devices[iDevice].GetLinkedFireOptions() == CDeviceClass::lkfSelected ?
+					iDevice == iEarliestLkfSelectedItem : true) : true))
 			return iDevice;
 		}
 
@@ -773,7 +776,7 @@ void CDeviceSystem::ReadyNextWeapon (CSpaceObject *pObj, int iDir)
 //	Select the next weapon.
 
 	{
-	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devPrimaryWeapon], itemcatWeapon, iDir);
+	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devPrimaryWeapon], itemcatWeapon, iDir, true);
 	if (iNextWeapon != -1)
 		{
 		m_NamedDevices[devPrimaryWeapon] = iNextWeapon;

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -255,7 +255,7 @@ int CDeviceSystem::FindNamedIndex (const CItem &Item) const
 	return -1;
 	}
 
-int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons) const
+int CDeviceSystem::FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons) const
 
 //	FindNextIndex
 //

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -274,7 +274,7 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 
 	//	Loop until we find an appropriate device
 	//  If our current device has "fire if selected", then create an ordering of "fire if selected"
-	//  weapon types, which is based on the order of appearance of the first weapon of each type with "fire if selected".
+	//  weapon types, which is based on the order of appearance of the first enabled weapon of each type with "fire if selected".
 	//  Only return a "fire if selected" device if it is the FIRST such weapon of a given type.
 
 	TSortMap<DWORD, int> FireWhenSelectedDeviceTypes;
@@ -285,6 +285,7 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 			if (!m_Devices[i].IsEmpty()
 				&& m_Devices[i].GetCategory() == Category
 				&& m_Devices[i].GetLinkedFireOptions() == CDeviceClass::lkfSelected
+				&& m_Devices[i].IsEnabled()
 				&& !FireWhenSelectedDeviceTypes.Find(m_Devices[i].GetUNID()))
 				FireWhenSelectedDeviceTypes.Insert(m_Devices[i].GetUNID(), i);
 			}

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -255,7 +255,7 @@ int CDeviceSystem::FindNamedIndex (const CItem &Item) const
 	return -1;
 	}
 
-int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons, bool selectedFireVariants) const
+int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons) const
 
 //	FindNextIndex
 //

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -261,7 +261,7 @@ int CDeviceSystem::FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories
 //
 //	Finds the next device of the given category
 
-{
+	{
 	int iStartingSlot;
 
 	//	iStartingSlot is always >= GetCount() so that we can iterate

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -284,7 +284,7 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 		for (int i = 0; i < GetCount(); i++)
 			{
 			LONGLONG iTypeAndVariant = (m_Devices[i].GetLinkedFireOptions() &
-				CDeviceClass::lkfSelectedVariant ? CItemCtx(pObj, &m_Devices[i]).GetItemVariantNumber() : 0);
+				CDeviceClass::lkfSelectedVariant ? CItemCtx(pObj, &m_Devices[i]).GetItemVariantNumber() : 0xffffffff);
 			iTypeAndVariant = m_Devices[i].GetUNID() | (iTypeAndVariant << 32);
 			if (!m_Devices[i].IsEmpty()
 				&& m_Devices[i].GetCategory() == Category
@@ -299,7 +299,7 @@ int CDeviceSystem::FindNextIndex(CSpaceObject *pObj, int iStart, ItemCategories 
 		{
 		int iDevice = ((iDir * i) + iStartingSlot) % GetCount();
 		LONGLONG iTypeAndVariant = (m_Devices[iDevice].GetLinkedFireOptions() &
-			CDeviceClass::lkfSelectedVariant ? CItemCtx(pObj, &m_Devices[iDevice]).GetItemVariantNumber() : 0);
+			CDeviceClass::lkfSelectedVariant ? CItemCtx(pObj, &m_Devices[iDevice]).GetItemVariantNumber() : 0xffffffff);
 		iTypeAndVariant = m_Devices[iDevice].GetUNID() | (iTypeAndVariant << 32);
 		int iEarliestLkfSelectedItem = -1;
 		FireWhenSelectedDeviceTypes.Find(iTypeAndVariant, &iEarliestLkfSelectedItem);

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -60,6 +60,7 @@ CInstalledDevice::CInstalledDevice (void) :
 		m_fFateComponetized(false),
 		m_fLinkedFireSelected(false),
 		m_fLinkedFireNever(false),
+		m_fLinkedFireSelectedVariants(false),
 		m_fCycleFire(false)
 	{
 	}
@@ -249,6 +250,8 @@ DWORD CInstalledDevice::GetLinkedFireOptions (void) const
 		return CDeviceClass::lkfEnemyInRange;
 	else if (m_fLinkedFireSelected)
 		return CDeviceClass::lkfSelected;
+	else if (m_fLinkedFireSelectedVariants)
+		return CDeviceClass::lkfSelectedVariant;
 	else if (m_fLinkedFireNever)
 		return CDeviceClass::lkfNever;
 	else
@@ -487,7 +490,8 @@ bool CInstalledDevice::IsSelectable (CItemCtx &Ctx) const
 	{
 	return (!IsSecondaryWeapon()
 			&& (GetClass()->GetLinkedFireOptions(Ctx) == 0
-			|| GetClass()->GetLinkedFireOptions(Ctx) == CDeviceClass::lkfSelected));
+			|| GetClass()->GetLinkedFireOptions(Ctx) == CDeviceClass::lkfSelected
+			|| GetClass()->GetLinkedFireOptions(Ctx) == CDeviceClass::lkfSelectedVariant));
 	}
 
 ALERROR CInstalledDevice::OnDesignLoadComplete (SDesignLoadCtx &Ctx)
@@ -763,7 +767,8 @@ void CInstalledDevice::ReadFromStream (CSpaceObject *pSource, SLoadCtx &Ctx)
 	bool bSlotEnhancements =((dwLoad & 0x00100000) ? true : false);
 	m_fLinkedFireSelected = ((dwLoad & 0x00200000) ? true : false);
 	m_fLinkedFireNever =	((dwLoad & 0x00400000) ? true : false);
-	m_fCycleFire =		((dwLoad & 0x00800000) ? true : false);
+	m_fLinkedFireSelectedVariants = ((dwLoad & 0x00800000) ? true : false);
+	m_fCycleFire =		((dwLoad & 0x01000000) ? true : false);
 
 	//	Previous versions did not save this flag
 
@@ -966,6 +971,7 @@ void CInstalledDevice::SetLinkedFireOptions (DWORD dwOptions)
 	m_fLinkedFireTarget = false;
 	m_fLinkedFireEnemy = false;
 	m_fLinkedFireSelected = false;
+	m_fLinkedFireSelectedVariants = false;
 	m_fLinkedFireNever = false;
 	if (dwOptions & CDeviceClass::lkfAlways)
 		m_fLinkedFireAlways = true;
@@ -975,6 +981,8 @@ void CInstalledDevice::SetLinkedFireOptions (DWORD dwOptions)
 		m_fLinkedFireEnemy = true;
 	else if (dwOptions & CDeviceClass::lkfSelected)
 		m_fLinkedFireSelected = true;
+	else if (dwOptions & CDeviceClass::lkfSelectedVariant)
+		m_fLinkedFireSelectedVariants = true;
 	else if (dwOptions & CDeviceClass::lkfNever)
 		m_fLinkedFireNever = true;
 	}
@@ -1358,7 +1366,8 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 	dwSave |= (!m_SlotEnhancements.IsEmpty() ? 0x00100000 : 0);
 	dwSave |= (m_fLinkedFireSelected ?	0x00200000 : 0);
 	dwSave |= (m_fLinkedFireNever ?		0x00400000 : 0);
-	dwSave |= (m_fCycleFire ? 			0x00800000 : 0);
+	dwSave |= (m_fLinkedFireSelectedVariants ? 0x00800000 : 0);
+	dwSave |= (m_fCycleFire ?			0x01000000 : 0);
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	CItemEnhancementStack::WriteToStream(m_pEnhancements, pStream);

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -9,6 +9,7 @@
 #define ITEM_ATTRIB								CONSTLIT("item")
 
 #define PROPERTY_CAPACITOR      				CONSTLIT("capacitor")
+#define PROPERTY_CYCLE_FIRE 					CONSTLIT("cycleFire")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
 #define PROPERTY_EXTRA_POWER_USE				CONSTLIT("extraPowerUse")
@@ -58,7 +59,8 @@ CInstalledDevice::CInstalledDevice (void) :
 		m_fFateSurvives(false),
 		m_fFateComponetized(false),
 		m_fLinkedFireSelected(false),
-		m_fLinkedFireNever(false)
+		m_fLinkedFireNever(false),
+		m_fCycleFire(false)
 	{
 	}
 
@@ -761,6 +763,7 @@ void CInstalledDevice::ReadFromStream (CSpaceObject *pSource, SLoadCtx &Ctx)
 	bool bSlotEnhancements =((dwLoad & 0x00100000) ? true : false);
 	m_fLinkedFireSelected = ((dwLoad & 0x00200000) ? true : false);
 	m_fLinkedFireNever =	((dwLoad & 0x00400000) ? true : false);
+	m_fCycleFire =		((dwLoad & 0x00800000) ? true : false);
 
 	//	Previous versions did not save this flag
 
@@ -1001,6 +1004,15 @@ bool CInstalledDevice::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem
             return false;
             }
         }
+
+	else if (strEquals(sName, PROPERTY_CYCLE_FIRE))
+		{
+		if (pValue == NULL || !pValue->IsNil())
+			SetCycleFireSettings(true);
+		else
+			SetCycleFireSettings(false);
+		}
+
 	else if (strEquals(sName, PROPERTY_EXTERNAL))
 		{
 		bool bSetExternal = (pValue && !pValue->IsNil());
@@ -1346,6 +1358,7 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 	dwSave |= (!m_SlotEnhancements.IsEmpty() ? 0x00100000 : 0);
 	dwSave |= (m_fLinkedFireSelected ?	0x00200000 : 0);
 	dwSave |= (m_fLinkedFireNever ?		0x00400000 : 0);
+	dwSave |= (m_fCycleFire ? 			0x00800000 : 0);
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	CItemEnhancementStack::WriteToStream(m_pEnhancements, pStream);

--- a/Mammoth/TSE/CItem.cpp
+++ b/Mammoth/TSE/CItem.cpp
@@ -3086,6 +3086,7 @@ bool CItem::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem *pValue, C
 			
 		SetCharges(pValue->GetIntegerValue());
 		}
+
 	else if (strEquals(sName, PROPERTY_DAMAGED))
 		SetDamaged((pValue == NULL) || !pValue->IsNil());
 

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -620,13 +620,16 @@ bool CShip::CalcDeviceTarget (STargetingCtx &Ctx, CItemCtx &ItemCtx, CSpaceObjec
 		DWORD dwLinkedFireOptions = pWeapon->GetLinkedFireOptions(ItemCtx);
 
 		CInstalledDevice *pPrimaryWeapon = GetNamedDevice(devPrimaryWeapon);
+		CInstalledDevice *pSelectedLauncher = GetNamedDevice(devMissileWeapon);
 
 		//  If our options is "never fire", or if our options is "fire if selected" and this is the player ship,
-		//  but the primary weapon isn't both "fire if selected" AND of the same type, then don't fire.
+		//  but the primary weapon or launcher isn't both "fire if selected" AND of the same type, then don't fire.
 
 		if ((dwLinkedFireOptions & CDeviceClass::lkfNever) || (
-			!((pPrimaryWeapon != NULL ? (pPrimaryWeapon->GetLinkedFireOptions() & CDeviceClass::lkfSelected) : false) &&
-			(pPrimaryWeapon != NULL ? (pPrimaryWeapon->GetUNID() == pWeapon->GetUNID()) : false)) &&
+			((!((pPrimaryWeapon != NULL ? (pPrimaryWeapon->GetLinkedFireOptions() & CDeviceClass::lkfSelected) : false) &&
+			(pPrimaryWeapon != NULL ? (pPrimaryWeapon->GetUNID() == pWeapon->GetUNID()) : false)) && (pWeapon->GetCategory() == itemcatWeapon)) ||
+				(!((pSelectedLauncher != NULL ? (pSelectedLauncher->GetLinkedFireOptions() & CDeviceClass::lkfSelected) : false) &&
+			(pSelectedLauncher != NULL ? (pSelectedLauncher->GetUNID() == pWeapon->GetUNID()) : false)) && (pWeapon->GetCategory() == itemcatLauncher))) &&
 			(dwLinkedFireOptions & CDeviceClass::lkfSelected) &&
 			IsPlayer()
 			))
@@ -6230,7 +6233,7 @@ void CShip::OnUpdate (SUpdateCtx &Ctx, Metric rSecondsPerTick)
 								CInstalledDevice *currDevice = GetDevice(i);
 								if (!currDevice->IsEmpty())
 									{
-									if (currDevice->GetCategory() == (itemcatWeapon))
+									if ((currDevice->GetCategory() == (itemcatWeapon)) || (currDevice->GetCategory() == (itemcatLauncher)))
 										{
 										if (iGunUNID == currDevice->GetUNID() && currDevice->GetLinkedFireOptions() == dwLinkedFireOptions && currDevice->GetCycleFireSettings()
 											&& currDevice != pDevice && currDevice->IsEnabled())

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -626,15 +626,13 @@ bool CShip::CalcDeviceTarget (STargetingCtx &Ctx, CItemCtx &ItemCtx, CSpaceObjec
 
 		//  If our options is "never fire", or if our options is "fire if selected" and this is the player ship,
 		//  but the primary weapon or launcher isn't both "fire if selected" AND of the same type, then don't fire.
-		//  If a weapon is "fire if selected and same variant", then it only fires if the selected weapon is of the
+		//  If a weapon is "fire if selected and same variant", then it only fires if the primary weapon is of the
 		//  same variant and type.
 		DWORD dwLinkedFireSelected = CDeviceClass::lkfSelected | CDeviceClass::lkfSelectedVariant;
-		int iTest1 = ItemCtx.GetItemVariantNumber();
-		int iTest2 = CItemCtx(this, pPrimaryWeapon).GetItemVariantNumber();
 
-		bool bPrimaryWeaponCheckVariant = pPrimaryWeapon != NULL ? (pPrimaryWeapon->GetLinkedFireOptions()
+		bool bPrimaryWeaponCheckVariant = pPrimaryWeapon != NULL ? (dwLinkedFireOptions
 			& CDeviceClass::lkfSelectedVariant ? ItemCtx.GetItemVariantNumber() == CItemCtx(this, pPrimaryWeapon).GetItemVariantNumber() : true) : false;
-		bool bSelectedLauncherCheckVariant = pSelectedLauncher != NULL ? (pSelectedLauncher->GetLinkedFireOptions()
+		bool bSelectedLauncherCheckVariant = pSelectedLauncher != NULL ? (dwLinkedFireOptions
 			& CDeviceClass::lkfSelectedVariant ? ItemCtx.GetItemVariantNumber() == CItemCtx(this, pSelectedLauncher).GetItemVariantNumber() : true) : false;
 
 		if ((dwLinkedFireOptions & CDeviceClass::lkfNever) || (

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -2544,11 +2544,13 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice)
 				{
 				if (currDevice.GetCategory() == (itemcatWeapon))
 					{
+					CItemCtx ItemCtx(this, pDevice);
 					bool bCheckSameVariant = currDevice.GetLinkedFireOptions() & CDeviceClass::lkfSelectedVariant ?
-						CItemCtx(this, pDevice).GetItemVariantNumber() == CItemCtx(this, &currDevice).GetItemVariantNumber() : true;
+						ItemCtx.GetItemVariantNumber() == CItemCtx(this, &currDevice).GetItemVariantNumber() : true;
 					if (iGunUNID == currDevice.GetUNID() && (currDevice.GetLinkedFireOptions() & dwLinkedFireSelected) && bCheckSameVariant)
 						{
-						if (pCurrDeviceClass->IsAmmoWeapon() && !(pCurrDeviceClass->RequiresItems()))
+						bool bUsesItemsForAmmo = (pCurrDeviceClass->AsWeaponClass()->GetWeaponFireDesc(ItemCtx)->GetAmmoType() != NULL);
+						if (pCurrDeviceClass->IsAmmoWeapon() && !bUsesItemsForAmmo)
 							//  If it is an ammo weapon, but does not require items, then it is a charges weapon. Add its ammo to the count.
 							{
 							int iAmmoLeft = 0;
@@ -2556,7 +2558,7 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice)
 							iAmmoCount += iAmmoLeft;
 							}
 
-						if (pCurrDeviceClass->IsAmmoWeapon() && (pCurrDeviceClass->RequiresItems()))
+						if (pCurrDeviceClass->IsAmmoWeapon() && bUsesItemsForAmmo)
 							//  If it is an ammo weapon, and also require items, then it is an ammo weapon. Add its ammo to the count ONLY if the ammo type
 							//  hasn't already been added.
 							{

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -645,9 +645,9 @@ bool CShip::CalcDeviceTarget (STargetingCtx &Ctx, CItemCtx &ItemCtx, CSpaceObjec
 			(dwLinkedFireOptions & dwLinkedFireSelected) &&
 			IsPlayer()
 			))
-		{
+			{
 			return false;
-		}
+			}
 
 		//	If our options is "fire always" or "fire if selected" then our target is always the same
 		//	as the primary target.

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -2524,32 +2524,35 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice)
 			{
 			CInstalledDevice currDevice = m_Devices.GetDevice(i);
 			CDeviceClass *pCurrDeviceClass = currDevice.GetClass();
-			if (currDevice.GetCategory() == (itemcatWeapon))
+			if (!currDevice.IsEmpty())
 				{
-				if (iGunUNID == currDevice.GetUNID() && currDevice.GetLinkedFireOptions() == CDeviceClass::lkfSelected)
+				if (currDevice.GetCategory() == (itemcatWeapon))
 					{
-					if (pCurrDeviceClass->IsAmmoWeapon() && !(pCurrDeviceClass->RequiresItems()))
-						//  If it is an ammo weapon, but does not require items, then it is a charges weapon. Add its ammo to the count.
+					if (iGunUNID == currDevice.GetUNID() && currDevice.GetLinkedFireOptions() == CDeviceClass::lkfSelected)
 						{
-						int iAmmoLeft = 0;
-						pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft);
-						iAmmoCount += iAmmoLeft;
-						}
+						if (pCurrDeviceClass->IsAmmoWeapon() && !(pCurrDeviceClass->RequiresItems()))
+							//  If it is an ammo weapon, but does not require items, then it is a charges weapon. Add its ammo to the count.
+							{
+							int iAmmoLeft = 0;
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft);
+							iAmmoCount += iAmmoLeft;
+							}
 
-					if (pCurrDeviceClass->IsAmmoWeapon() && (pCurrDeviceClass->RequiresItems()))
-						//  If it is an ammo weapon, and also require items, then it is an ammo weapon. Add its ammo to the count ONLY if the ammo type
-						//  hasn't already been added.
-						{
-						bool ammoIsAdded = false;
-						int iAmmoLeft = 0;
-						CItemType *pAmmoType;
-						pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, &pAmmoType);
-						AmmoItemTypes.Find(pAmmoType, &ammoIsAdded);
+						if (pCurrDeviceClass->IsAmmoWeapon() && (pCurrDeviceClass->RequiresItems()))
+							//  If it is an ammo weapon, and also require items, then it is an ammo weapon. Add its ammo to the count ONLY if the ammo type
+							//  hasn't already been added.
+							{
+							bool ammoIsAdded = false;
+							int iAmmoLeft = 0;
+							CItemType *pAmmoType;
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, &pAmmoType);
+							AmmoItemTypes.Find(pAmmoType, &ammoIsAdded);
 							if (!ammoIsAdded)
 								{
 								AmmoItemTypes.Insert(pAmmoType, true);
 								iAmmoCount += iAmmoLeft;
 								}
+							}
 						}
 					}
 				}
@@ -6225,16 +6228,18 @@ void CShip::OnUpdate (SUpdateCtx &Ctx, Metric rSecondsPerTick)
 							for (int i = 0; i < m_Devices.GetCount(); i++)
 								{
 								CInstalledDevice *currDevice = GetDevice(i);
-								CDeviceClass *pCurrDeviceClass = currDevice->GetClass();
-								if (currDevice->GetCategory() == (itemcatWeapon))
+								if (!currDevice->IsEmpty())
 									{
-									if (iGunUNID == currDevice->GetUNID() && currDevice->GetLinkedFireOptions() == dwLinkedFireOptions && currDevice->GetCycleFireSettings()
-										&& currDevice != pDevice && currDevice->IsEnabled())
+									if (currDevice->GetCategory() == (itemcatWeapon))
 										{
-										//  Add the items to a linked list object. We'll then iterate through that linked list, and increment the fire delays.
-										iNumberOfGuns++;
-										if (currDevice->IsReady())
-											WeaponsInFireGroup.Enqueue(currDevice);
+										if (iGunUNID == currDevice->GetUNID() && currDevice->GetLinkedFireOptions() == dwLinkedFireOptions && currDevice->GetCycleFireSettings()
+											&& currDevice != pDevice && currDevice->IsEnabled())
+											{
+											//  Add the items to a linked list object. We'll then iterate through that linked list, and increment the fire delays.
+											iNumberOfGuns++;
+											if (currDevice->IsReady())
+												WeaponsInFireGroup.Enqueue(currDevice);
+											}
 										}
 									}
 								}

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -2483,7 +2483,10 @@ ICCItem *CWeaponClass::FindAmmoItemProperty (CItemCtx &Ctx, const CItem &Ammo, c
 			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfTargetInRange));
 		else if (dwOptions & CDeviceClass::lkfEnemyInRange)
 			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfEnemyInRange));
-
+		else if (dwOptions & CDeviceClass::lkfSelected)
+			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfSelected));
+		else if (dwOptions & CDeviceClass::lkfNever)
+			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfNever));
 		//	Done
 
 		return pResult;

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -2485,6 +2485,8 @@ ICCItem *CWeaponClass::FindAmmoItemProperty (CItemCtx &Ctx, const CItem &Ammo, c
 			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfEnemyInRange));
 		else if (dwOptions & CDeviceClass::lkfSelected)
 			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfSelected));
+		else if (dwOptions & CDeviceClass::lkfSelectedVariant)
+			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfSelectedVariant));
 		else if (dwOptions & CDeviceClass::lkfNever)
 			pList->AppendString(CDeviceClass::GetLinkedFireOptionString(CDeviceClass::lkfNever));
 		//	Done

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -32,6 +32,7 @@
 #define LINKED_FIRE_ENEMY						CONSTLIT("whenInFireArc")
 #define LINKED_FIRE_TARGET						CONSTLIT("targetInRange")
 #define LINKED_FIRE_SELECTED					CONSTLIT("whenSelected")
+#define LINKED_FIRE_SELECTED_VARIANT			CONSTLIT("whenSelectedSameVariant")
 #define LINKED_FIRE_NEVER						CONSTLIT("neverFire")
 
 #define PROPERTY_CAN_BE_DAMAGED					CONSTLIT("canBeDamaged")
@@ -701,6 +702,9 @@ CString CDeviceClass::GetLinkedFireOptionString (DWORD dwOptions)
 		case lkfSelected:
 			return LINKED_FIRE_SELECTED;
 
+		case lkfSelectedVariant:
+			return LINKED_FIRE_SELECTED_VARIANT;
+
 		case lkfNever:
 			return LINKED_FIRE_NEVER;
 
@@ -826,6 +830,8 @@ ALERROR CDeviceClass::ParseLinkedFireOptions (SDesignLoadCtx &Ctx, const CString
 		dwOptions |= CDeviceClass::lkfEnemyInRange;
 	else if (strEquals(sDesc, LINKED_FIRE_SELECTED))
 		dwOptions |= CDeviceClass::lkfSelected;
+	else if (strEquals(sDesc, LINKED_FIRE_SELECTED_VARIANT))
+		dwOptions |= CDeviceClass::lkfSelectedVariant;
 	else if (strEquals(sDesc, LINKED_FIRE_NEVER))
 		dwOptions |= CDeviceClass::lkfNever;
 	else

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -38,6 +38,7 @@
 #define PROPERTY_CAN_BE_DISABLED				CONSTLIT("canBeDisabled")
 #define PROPERTY_CAN_BE_DISRUPTED				CONSTLIT("canBeDisrupted")
 #define PROPERTY_CAPACITOR      				CONSTLIT("capacitor")
+#define PROPERTY_CYCLE_FIRE 					CONSTLIT("cycleFire")
 #define PROPERTY_DEVICE_SLOTS					CONSTLIT("deviceSlots")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
@@ -489,6 +490,9 @@ ICCItem *CDeviceClass::FindItemProperty (CItemCtx &Ctx, const CString &sName)
 
         return CC.CreateInteger(iLevel);
         }
+
+	else if (strEquals(sName, PROPERTY_CYCLE_FIRE))
+		return (pDevice ? CC.CreateBool(pDevice->GetCycleFireSettings()) : CC.CreateNil());
 
     else if (strEquals(sName, PROPERTY_DEVICE_SLOTS))
         return CC.CreateInteger(GetSlotsRequired());

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -31,6 +31,8 @@
 #define LINKED_FIRE_ALWAYS						CONSTLIT("always")
 #define LINKED_FIRE_ENEMY						CONSTLIT("whenInFireArc")
 #define LINKED_FIRE_TARGET						CONSTLIT("targetInRange")
+#define LINKED_FIRE_SELECTED					CONSTLIT("whenSelected")
+#define LINKED_FIRE_NEVER						CONSTLIT("neverFire")
 
 #define PROPERTY_CAN_BE_DAMAGED					CONSTLIT("canBeDamaged")
 #define PROPERTY_CAN_BE_DISABLED				CONSTLIT("canBeDisabled")
@@ -121,7 +123,7 @@ void CDeviceClass::AccumulateAttributes (CItemCtx &ItemCtx, const CItem &Ammo, T
 		//	Linked-fire
 
 		DWORD dwOptions = GetLinkedFireOptions(ItemCtx);
-		if (dwOptions != 0)
+		if ((dwOptions != 0) && (dwOptions != CDeviceClass::lkfNever))
 			retList->Insert(SDisplayAttribute(attribPositive, CONSTLIT("linked-fire")));
 		}
 
@@ -692,6 +694,12 @@ CString CDeviceClass::GetLinkedFireOptionString (DWORD dwOptions)
 		case lkfEnemyInRange:
 			return LINKED_FIRE_ENEMY;
 
+		case lkfSelected:
+			return LINKED_FIRE_SELECTED;
+
+		case lkfNever:
+			return LINKED_FIRE_NEVER;
+
 		default:
 			ASSERT(false);
 			return NULL_STR;
@@ -812,6 +820,10 @@ ALERROR CDeviceClass::ParseLinkedFireOptions (SDesignLoadCtx &Ctx, const CString
 		dwOptions |= CDeviceClass::lkfTargetInRange;
 	else if (strEquals(sDesc, LINKED_FIRE_ENEMY))
 		dwOptions |= CDeviceClass::lkfEnemyInRange;
+	else if (strEquals(sDesc, LINKED_FIRE_SELECTED))
+		dwOptions |= CDeviceClass::lkfSelected;
+	else if (strEquals(sDesc, LINKED_FIRE_NEVER))
+		dwOptions |= CDeviceClass::lkfNever;
 	else
 		{
 		Ctx.sError = strPatternSubst(CONSTLIT("Invalid linkedFire option: %s"), sDesc);

--- a/Mammoth/TSUI/CWeaponHUDCircular.cpp
+++ b/Mammoth/TSUI/CWeaponHUDCircular.cpp
@@ -285,6 +285,9 @@ void CWeaponHUDCircular::PaintWeaponStatus (CShip *pShip, CInstalledDevice *pDev
 	CString sVariant;
 	int iAmmoLeft;
 	pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft);
+	int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
+	if (iSelectedFireAmmoLeft >= 0)
+		iAmmoLeft = iSelectedFireAmmoLeft;
 	CString sDevName = pDevice->GetItem()->GetNounPhrase(ItemCtx, nounDuplicateModifier | nounNoModifiers);
 	CString sName = (sVariant.IsBlank() ? sDevName : sVariant);
 
@@ -333,6 +336,7 @@ void CWeaponHUDCircular::PaintWeaponStatus (CShip *pShip, CInstalledDevice *pDev
 		}
 
 	//	Paint the ammo count
+	//  TODO: If using LinkedFireSelectable, get the TOTAL ammo count of all weapons.
 
 	if (iAmmoLeft != -1)
 		LargeBoldFont.DrawText(m_Buffer,

--- a/Mammoth/TSUI/CWeaponHUDDefault.cpp
+++ b/Mammoth/TSUI/CWeaponHUDDefault.cpp
@@ -147,6 +147,9 @@ void CWeaponHUDDefault::PaintDeviceStatus (CShip *pShip, DeviceNames iDev, int x
 		CString sVariant;
 		int iAmmoLeft;
 		pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft);
+		int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
+		if (iSelectedFireAmmoLeft >= 0)
+			iAmmoLeft = iSelectedFireAmmoLeft;
 		CString sDevName = pClass->GetName();
 
 		//	Paint the bonus

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -2368,7 +2368,7 @@ void CPlayerShipController::ReadyNextWeapon (int iDir)
 	while (pNewWeapon 
 			&& pCurWeapon
 			&& pNewWeapon != pCurWeapon
-			&& (bCurWeaponLkfSelected ? (bNextWeaponLkfSelected ? true : !pNewWeapon->IsEnabled()) : !pNewWeapon->IsEnabled()));
+			&& (bCurWeaponLkfSelected ? (bNextWeaponLkfSelected ? pNewWeapon->GetUNID() != pCurWeapon->GetUNID() : !pNewWeapon->IsEnabled()) : !pNewWeapon->IsEnabled()));
 
 	//	Done
 

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -2374,9 +2374,10 @@ void CPlayerShipController::ReadyNextWeapon (int iDir)
 
 	if (pNewWeapon)
 		{
-		//	There is a delay in activation
+		//	There is a delay in activation (except for linkedFire='whenSelected' guns)
 
-		m_pShip->SetFireDelay(pNewWeapon);
+		if (!(pNewWeapon->GetLinkedFireOptions() & CDeviceClass::lkfSelected))
+			m_pShip->SetFireDelay(pNewWeapon);
 
 		//	Feedback to player
 

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -2350,18 +2350,25 @@ void CPlayerShipController::ReadyNextWeapon (int iDir)
 	{
 	CInstalledDevice *pCurWeapon = m_pShip->GetNamedDevice(devPrimaryWeapon);
 	CInstalledDevice *pNewWeapon = pCurWeapon;
+	bool bCurWeaponLkfSelected = pCurWeapon->GetLinkedFireOptions() == CDeviceClass::lkfSelected;
+	bool bNextWeaponLkfSelected = (pNewWeapon->GetLinkedFireOptions() == CDeviceClass::lkfSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID());
 
 	//	Keep switching until we find a weapon that is not disabled
+	//  If currently selected weapon has LinkedFireSelectable, make sure next
+	//  selected weapon is not (both of the same type AND set as linkedFire="LinkedFireSelected")
+	//  Only then do we check to see if the weapon is enabled.
 
 	do
 		{
 		m_pShip->ReadyNextWeapon(iDir);
 		pNewWeapon = m_pShip->GetNamedDevice(devPrimaryWeapon);
+		bCurWeaponLkfSelected = pCurWeapon->GetLinkedFireOptions() == CDeviceClass::lkfSelected;
+		bNextWeaponLkfSelected = (pNewWeapon->GetLinkedFireOptions() == CDeviceClass::lkfSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID());
 		}
 	while (pNewWeapon 
 			&& pCurWeapon
 			&& pNewWeapon != pCurWeapon
-			&& !pNewWeapon->IsEnabled());
+			&& (bCurWeaponLkfSelected ? (bNextWeaponLkfSelected ? true : !pNewWeapon->IsEnabled()) : !pNewWeapon->IsEnabled()));
 
 	//	Done
 

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -2352,10 +2352,10 @@ void CPlayerShipController::ReadyNextWeapon (int iDir)
 	CInstalledDevice *pNewWeapon = pCurWeapon;
 	DWORD dwLinkedFireSelected = CDeviceClass::lkfSelected | CDeviceClass::lkfSelectedVariant;
 
-	DWORD bCurWeaponLkfSelected = pCurWeapon->GetLinkedFireOptions() & dwLinkedFireSelected;
-	DWORD bNextWeaponLkfSelected = (pNewWeapon->GetLinkedFireOptions() & dwLinkedFireSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID()
+	DWORD bCurWeaponLkfSelected = (pCurWeapon != NULL) ? pCurWeapon->GetLinkedFireOptions() & dwLinkedFireSelected : 0x0;
+	DWORD bNextWeaponLkfSelected = (pCurWeapon != NULL) ? (pNewWeapon->GetLinkedFireOptions() & dwLinkedFireSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID()
 		&& (pNewWeapon->GetLinkedFireOptions() & CDeviceClass::lkfSelectedVariant ? CItemCtx(m_pShip, pNewWeapon).GetItemVariantNumber() == CItemCtx(m_pShip, pCurWeapon).GetItemVariantNumber()
-			: true));
+			: true)) : 0x0;
 
 	//	Keep switching until we find a weapon that is not disabled
 	//  If currently selected weapon has LinkedFireSelectable, make sure next
@@ -2366,10 +2366,10 @@ void CPlayerShipController::ReadyNextWeapon (int iDir)
 		{
 		m_pShip->ReadyNextWeapon(iDir);
 		pNewWeapon = m_pShip->GetNamedDevice(devPrimaryWeapon);
-		bCurWeaponLkfSelected = pCurWeapon->GetLinkedFireOptions() & dwLinkedFireSelected;
-		bNextWeaponLkfSelected = (pNewWeapon->GetLinkedFireOptions() & dwLinkedFireSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID()
+		bCurWeaponLkfSelected = (pCurWeapon != NULL) ? pCurWeapon->GetLinkedFireOptions() & dwLinkedFireSelected : 0x0;
+		bNextWeaponLkfSelected = (pCurWeapon != NULL) ? (pNewWeapon->GetLinkedFireOptions() & dwLinkedFireSelected && pNewWeapon->GetUNID() == pCurWeapon->GetUNID()
 			&& (pNewWeapon->GetLinkedFireOptions() & CDeviceClass::lkfSelectedVariant ? CItemCtx(m_pShip, pNewWeapon).GetItemVariantNumber() == CItemCtx(m_pShip, pCurWeapon).GetItemVariantNumber()
-				: true));
+				: true)) : 0x0;
 		}
 	
 	while (pNewWeapon 


### PR DESCRIPTION
The new linked fire option `"whenSelected"` allows installing multiple weapons of the same type on a (player) ship, then selecting them all as one weapon. For example, if we have 3 laser cannons and a SmartCannon on the player ship, and all of the lasers have the `"whenSelected"` linked fire option, cycling through the guns with "W" will give us 2 options: "laser cannon" (which selects the 3 lasers) and "SmartCannon" (which selects the SmartCannon).

I've included an example of this in action at https://gfycat.com/RevolvingMinorIcelandicsheepdog. The player ship in this case has: 3 light ion blasters, 2 positron lancers, and 2 Akan 30 cannons all with `linkedFireOptions='whenSelected'`. There is also a (single) dual laser cannon installed, which does not have `"whenSelected"` (or any other linked fire options) set.

If the linked fire weapons use charges or ammo, then the HUD will display the correct number of rounds remaining for all guns. This can be seen in the video: https://gfycat.com/InbornFewGroundbeetle, where the player ship is armed with 5 Gaian demolition cannons: 4 with `linkedFireOptions='whenSelected'`, and the fifth without any linked fire options set.

The new linked fire option `"neverFire"`, on the other hand, simply prevents the gun from being fired. Kinda like disabling the gun, but unlike disabling the gun this still allows it to recharge (and other things that can only be done when enabled).

EDIT: Another linked fire option has been added: `linkedFireOptions="whenSelectedSameVariant"`. This is identical to `linkedFireOptions="whenSelected"`, with the exception that it enables weapons of the same UNID **AND** variant to be selected as a firing group. As of now, this only works with counter-type variants, of the type introduced in #5.