### PR TITLE
Added multiple launcher support to player ships.

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -111,6 +111,8 @@ class CCyberDeckClass : public CDeviceClass
 											 CItemType **retpType = NULL) override;
 		virtual int GetValidVariantCount (CSpaceObject *pSource, CInstalledDevice *pDevice) override { return 1; }
 		virtual int GetWeaponEffectiveness (CSpaceObject *pSource, CInstalledDevice *pDevice, CSpaceObject *pTarget) override;
+		virtual bool IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice) override { return true; }
+		virtual bool IsLastVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) override { return true; }
 		virtual bool IsVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) override { return true; }
 		virtual bool IsWeaponAligned (CSpaceObject *pShip, CInstalledDevice *pDevice, CSpaceObject *pTarget, int *retiAimAngle = NULL, int *retiFireAngle = NULL) override;
 		virtual bool SelectFirstVariant (CSpaceObject *pSource, CInstalledDevice *pDevice) override { return true; }
@@ -685,8 +687,10 @@ class CWeaponClass : public CDeviceClass
 		virtual int GetWeaponEffectiveness (CSpaceObject *pSource, CInstalledDevice *pDevice, CSpaceObject *pTarget) override;
 		virtual bool IsAmmoWeapon (void) override;
 		virtual bool IsAreaWeapon (CSpaceObject *pSource, CInstalledDevice *pDevice) override;
+		virtual bool IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice) override;
 		virtual bool IsTrackingWeapon (CItemCtx &Ctx) override;
 		virtual bool IsVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) override;
+		virtual bool IsLastVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) override;
 		virtual bool IsWeaponAligned (CSpaceObject *pShip, CInstalledDevice *pDevice, CSpaceObject *pTarget, int *retiAimAngle = NULL, int *retiFireAngle = NULL) override;
 		virtual bool NeedsAutoTarget (CItemCtx &Ctx, int *retiMinFireArc = NULL, int *retiMaxFireArc = NULL) override;
 		virtual ALERROR OnDesignLoadComplete (SDesignLoadCtx &Ctx) override;

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -289,7 +289,9 @@ class CDeviceClass
 		virtual bool IsAreaWeapon (CSpaceObject *pSource, CInstalledDevice *pDevice) { return false; }
 		virtual bool IsAutomatedWeapon (void) { return false; }
 		virtual bool IsExternal (void) const { return (m_fExternal ? true : false); }
+		virtual bool IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice) { return true; }
 		virtual bool IsFuelCompatible (CItemCtx &Ctx, const CItem &FuelItem) { return false; }
+		virtual bool IsLastVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) { return true; }
 		virtual bool IsTrackingWeapon (CItemCtx &Ctx) { return false; }
 		virtual bool IsVariantSelected (CSpaceObject *pSource, CInstalledDevice *pDevice) { return true; }
 		virtual bool IsWeaponAligned (CSpaceObject *pShip, CInstalledDevice *pDevice, CSpaceObject *pTarget, int *retiAimAngle = NULL, int *retiFireAngle = NULL) { return false; }
@@ -591,7 +593,9 @@ class CInstalledDevice
 		int IncCharges (CSpaceObject *pSource, int iChange);
 		inline bool IsAutomatedWeapon (void) { return m_pClass->IsAutomatedWeapon(); }
 		inline bool IsAreaWeapon (CSpaceObject *pSource) { return m_pClass->IsAreaWeapon(pSource, this); }
+		inline bool IsFirstVariantSelected(CSpaceObject *pSource) { return (m_pClass ? m_pClass->IsFirstVariantSelected(pSource, this) : true); }
 		inline bool IsFuelCompatible (CItemCtx &Ctx, const CItem &FuelItem) { return m_pClass->IsFuelCompatible(Ctx, FuelItem); }
+		inline bool IsLastVariantSelected(CSpaceObject *pSource) { return (m_pClass ? m_pClass->IsLastVariantSelected(pSource, this) : true); }
 		bool IsLinkedFire (CItemCtx &Ctx, ItemCategories iTriggerCat = itemcatNone) const;
 		inline bool IsSecondaryWeapon (void) const;
 		bool IsSelectable (CItemCtx &Ctx) const;

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -102,7 +102,7 @@ class CDeviceSystem
 
 		int FindFreeSlot (void);
 		int FindNamedIndex (const CItem &Item) const;
-		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1) const;
+		int FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir = 1, bool switchWeapons = false) const;
 		int FindRandomIndex (bool bEnabledOnly) const;
 		bool FindWeaponByItem (const CItem &Item, int *retiIndex = NULL, int *retiVariant = NULL) const;
 		inline int GetCount (void) const { return m_Devices.GetCount(); }

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -117,8 +117,10 @@ class CDeviceSystem
 		void MarkImages (void);
 		bool OnDestroyCheck (CSpaceObject *pObj, DestructionTypes iCause, const CDamageSource &Attacker);
         void ReadFromStream (SLoadCtx &Ctx, CSpaceObject *pObj);
+		void ReadyFirstLauncher (CSpaceObject *pObj);
 		void ReadyFirstMissile (CSpaceObject *pObj);
 		void ReadyFirstWeapon (CSpaceObject *pObj);
+		void ReadyNextLauncher (CSpaceObject *pObj, int iDir = 1);
 		void ReadyNextMissile (CSpaceObject *pObj, int iDir = 1);
 		void ReadyNextWeapon (CSpaceObject *pObj, int iDir = 1);
 		DeviceNames SelectWeapon (CSpaceObject *pObj, int iIndex, int iVariant);

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -120,7 +120,7 @@ class CDeviceSystem
 		void ReadyFirstMissile (CSpaceObject *pObj);
 		void ReadyFirstWeapon (CSpaceObject *pObj);
 		void ReadyNextLauncher (CSpaceObject *pObj, int iDir = 1);
-		void ReadyNextMissile (CSpaceObject *pObj, int iDir = 1);
+		void ReadyNextMissile (CSpaceObject * pObj, int iDir = 1, bool bUsedLastAmmo = false);
 		void ReadyNextWeapon (CSpaceObject *pObj, int iDir = 1);
 		DeviceNames SelectWeapon (CSpaceObject *pObj, int iIndex, int iVariant);
 		void SetCursorAtDevice (CItemListManipulator &ItemList, int iIndex) const;

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -117,7 +117,6 @@ class CDeviceSystem
 		void MarkImages (void);
 		bool OnDestroyCheck (CSpaceObject *pObj, DestructionTypes iCause, const CDamageSource &Attacker);
         void ReadFromStream (SLoadCtx &Ctx, CSpaceObject *pObj);
-		void ReadyFirstLauncher (CSpaceObject *pObj);
 		void ReadyFirstMissile (CSpaceObject *pObj);
 		void ReadyFirstWeapon (CSpaceObject *pObj);
 		void ReadyNextLauncher (CSpaceObject *pObj, int iDir = 1);

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1010,8 +1010,6 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		void ReadyNextWeapon (int iDir = 1);
 		void ReadyFirstMissile (void);
 		void ReadyNextMissile (int iDir = 1);
-		void ReadyFirstLauncher(void);
-		void ReadyNextLauncher(int iDir = 1);
 		void RechargeItem (CItemListManipulator &ItemList, int iCharges);
 		int GetMissileCount (void);
 		ALERROR RemoveItemAsDevice (CItemListManipulator &ItemList);

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1009,7 +1009,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		void ReadyFirstWeapon (void);
 		void ReadyNextWeapon (int iDir = 1);
 		void ReadyFirstMissile (void);
-		void ReadyNextMissile (int iDir = 1);
+		void ReadyNextMissile (int iDir = 1, bool bUsedLastAmmo = false);
 		void RechargeItem (CItemListManipulator &ItemList, int iCharges);
 		int GetMissileCount (void);
 		ALERROR RemoveItemAsDevice (CItemListManipulator &ItemList);

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1010,6 +1010,8 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		void ReadyNextWeapon (int iDir = 1);
 		void ReadyFirstMissile (void);
 		void ReadyNextMissile (int iDir = 1);
+		void ReadyFirstLauncher(void);
+		void ReadyNextLauncher(int iDir = 1);
 		void RechargeItem (CItemListManipulator &ItemList, int iCharges);
 		int GetMissileCount (void);
 		ALERROR RemoveItemAsDevice (CItemListManipulator &ItemList);

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -726,7 +726,7 @@ void CDeviceSystem::ReadyNextLauncher(CSpaceObject *pObj, int iDir)
 //	Select the next launcher.
 
 {
-	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devMissileWeapon], itemcatLauncher, iDir);
+	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devMissileWeapon], itemcatLauncher, iDir, true);
 	if (iNextWeapon != -1)
 	{
 		m_NamedDevices[devMissileWeapon] = iNextWeapon;

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -770,8 +770,10 @@ void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir)
 			}
 		}
 	
-	//  If the last variant is selected, then select the next missile launcher.
+	//  If the last variant is selected, then select the previous missile launcher.
 	//  Don't forget to also select the first (or last) missile, too.
+	//  Note, we select the next missile launcher if the FIRST variant is selected, because we
+	//  were on the last variant before running this function (which moved us to the first one).
 
 	bool selectPrevLauncher = (lastSelected && (iDir == 0));
 	bool selectNextLauncher = (firstSelected && (iDir == 1));

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -721,7 +721,7 @@ void CDeviceSystem::ReadyFirstWeapon (CSpaceObject *pObj)
 
 void CDeviceSystem::ReadyNextLauncher(CSpaceObject *pObj, int iDir)
 
-//	ReadyNextWeapon
+//	ReadyNextLauncher
 //
 //	Select the next launcher.
 

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -776,12 +776,17 @@ void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir, bool bUsedLa
 
 	if (bUsedLastAmmo ? pDevice->GetValidVariantCount(pObj) == 0 : true)
 		{
-		bool selectPrevLauncher = (lastSelected && (iDir == 0));
-		bool selectNextLauncher = (firstSelected && (iDir == 1));
-		if (selectNextLauncher)
+		bool bselectPrevLauncher = (lastSelected && (iDir == 0));
+		bool bselectNextLauncher = (firstSelected && (iDir == 1));
+		
+		if ((bselectPrevLauncher || bselectNextLauncher) && (pObj->GetCategory() == CSpaceObject::catShip) && (pObj->IsPlayer()))
+			pObj->AsShip()->SetWeaponTriggered(devMissileWeapon, false);
+
+		if (bselectNextLauncher)
 			ReadyNextLauncher(pObj, 1);
-		else if (selectPrevLauncher)
+		else if (bselectPrevLauncher)
 			ReadyNextLauncher(pObj, 0);
+
 		}
 
 	}

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -726,7 +726,7 @@ void CDeviceSystem::ReadyNextLauncher(CSpaceObject *pObj, int iDir)
 //	Select the next launcher.
 
 {
-	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devMissileWeapon], itemcatLauncher, iDir, true);
+	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devMissileWeapon], itemcatLauncher, iDir);
 	if (iNextWeapon != -1)
 	{
 		m_NamedDevices[devMissileWeapon] = iNextWeapon;

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -255,7 +255,7 @@ int CDeviceSystem::FindNamedIndex (const CItem &Item) const
 	return -1;
 	}
 
-int CDeviceSystem::FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir) const
+int CDeviceSystem::FindNextIndex (CSpaceObject *pObj, int iStart, ItemCategories Category, int iDir, bool switchWeapons) const
 
 //	FindNextIndex
 //

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -737,14 +737,13 @@ void CDeviceSystem::ReadyNextLauncher(CSpaceObject *pObj, int iDir)
 	}
 }
 
-void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir)
+void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir, bool bUsedLastAmmo)
 
 //	ReadyNextMissile
 //
 //	Selects the next missile
 
 	{
-	int i;
 	bool lastSelected;
 	bool firstSelected;
 	CInstalledDevice *pDevice = GetNamedDevice(devMissileWeapon);
@@ -757,7 +756,7 @@ void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir)
 		//	If we have any linked missile launchers, then select them also
 		//  TODO: May need to change for SelectedFire launchers, as well as the fire command for SelectedFire launchers...
 
-		for (i = 0; i < m_Devices.GetCount(); i++)
+		for (int i = 0; i < m_Devices.GetCount(); i++)
 			{
 			CInstalledDevice &LinkedDevice = GetDevice(i);
 			CItemCtx Ctx(pObj, &LinkedDevice);
@@ -775,12 +774,15 @@ void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir)
 	//  Note, we select the next missile launcher if the FIRST variant is selected, because we
 	//  were on the last variant before running this function (which moved us to the first one).
 
-	bool selectPrevLauncher = (lastSelected && (iDir == 0));
-	bool selectNextLauncher = (firstSelected && (iDir == 1));
-	if (selectPrevLauncher)
-		ReadyNextLauncher(pObj, 0);
-	else if (selectNextLauncher)
-		ReadyNextLauncher(pObj, 1);
+	if (bUsedLastAmmo ? pDevice->GetValidVariantCount(pObj) == 0 : true)
+		{
+		bool selectPrevLauncher = (lastSelected && (iDir == 0));
+		bool selectNextLauncher = (firstSelected && (iDir == 1));
+		if (selectNextLauncher)
+			ReadyNextLauncher(pObj, 1);
+		else if (selectPrevLauncher)
+			ReadyNextLauncher(pObj, 0);
+		}
 
 	}
 

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -777,7 +777,7 @@ void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir, bool bUsedLa
 	if (bUsedLastAmmo ? pDevice->GetValidVariantCount(pObj) == 0 : true)
 		{
 		bool bselectPrevLauncher = (lastSelected && (iDir == 0));
-		bool bselectNextLauncher = (firstSelected && (iDir == 1));
+		bool bselectNextLauncher = ((firstSelected && (iDir == 1)) || (pDevice == NULL));
 		
 		if ((bselectPrevLauncher || bselectNextLauncher) && (pObj->GetCategory() == CSpaceObject::catShip) && (pObj->IsPlayer()))
 			pObj->AsShip()->SetWeaponTriggered(devMissileWeapon, false);

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -725,17 +725,17 @@ void CDeviceSystem::ReadyNextLauncher(CSpaceObject *pObj, int iDir)
 //
 //	Select the next launcher.
 
-{
+	{
 	int iNextWeapon = FindNextIndex(pObj, m_NamedDevices[devMissileWeapon], itemcatLauncher, iDir, true);
 	if (iNextWeapon != -1)
-	{
+		{
 		m_NamedDevices[devMissileWeapon] = iNextWeapon;
 
 		CInstalledDevice *pDevice = GetNamedDevice(devMissileWeapon);
 		CDeviceClass *pClass = pDevice->GetClass();
 		pClass->ValidateSelectedVariant(pObj, pDevice);
+		}
 	}
-}
 
 void CDeviceSystem::ReadyNextMissile (CSpaceObject *pObj, int iDir, bool bUsedLastAmmo)
 

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -911,7 +911,8 @@ bool CDeviceSystem::Uninstall (CSpaceObject *pObj, CItemListManipulator &ItemLis
 			break;
 
 		case itemcatLauncher:
-			m_NamedDevices[devMissileWeapon] = -1;
+			if (m_NamedDevices[devMissileWeapon] == iDevSlot)
+				m_NamedDevices[devMissileWeapon] = FindNextIndex(pObj, iDevSlot, itemcatLauncher);
 			break;
 
 		case itemcatShields:

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -4648,7 +4648,7 @@ void CShip::OnDeviceStatus (CInstalledDevice *pDev, CDeviceClass::DeviceNotifica
 
 			if (pMainLauncher == pDev 
 					|| (pMainLauncher && pMainLauncher->GetClass() == pDev->GetClass()))
-				ReadyNextMissile();
+				ReadyNextMissile(1, true);
 
 			//	Otherwise, if this is a launcher, we just switch its missiles.
 			//	This handles the case where we have heterogeneous missile launchers.
@@ -7027,14 +7027,14 @@ void CShip::ReadyFirstWeapon (void)
 	m_Devices.ReadyFirstWeapon(this);
 	}
 
-void CShip::ReadyNextMissile (int iDir)
+void CShip::ReadyNextMissile (int iDir, bool bUsedLastAmmo)
 
 //	ReadyNextMissile
 //
 //	Selects the next missile
 
 	{
-	m_Devices.ReadyNextMissile(this, iDir);
+	m_Devices.ReadyNextMissile(this, iDir, bUsedLastAmmo);
 	}
 
 void CShip::ReadyNextWeapon (int iDir)

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -3739,9 +3739,17 @@ bool CWeaponClass::IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevic
 //	IsVariantSelected
 //
 //	Returns TRUE if we've selected some variant (i.e., we haven't selected 0xffff)
+//  TODO: Make sure that this is the first variant WITH AVAILABLE AMMO that is selected.
+//  We can do this by making sure that the previous variant has an ID greater than the current one.
 
 {
-	return (GetCurrentVariant(pDevice) == -1) || (GetCurrentVariant(pDevice) == 0);
+	bool bFirstVariantSelected = true;
+	for (int iTry = GetCurrentVariant(pDevice) - 1; iTry >= 0; iTry--)
+	{
+		//  If any variant with lower ID than our current one is valid, then the first variant is NOT currently selected.
+		bFirstVariantSelected = bFirstVariantSelected && !(VariantIsValid(pSource, pDevice, *m_ShotData[iTry].pDesc));
+	}
+	return ((GetCurrentVariant(pDevice) == -1) || bFirstVariantSelected);
 }
 
 bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice)
@@ -3749,9 +3757,17 @@ bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice
 //	IsVariantSelected
 //
 //	Returns TRUE if we've selected some variant (i.e., we haven't selected 0xffff)
+//  TODO: Make sure that this is the last variant WITH AVAILABLE AMMO that is selected.
+//  We can do this by making sure that the next variant has an ID less than the current one.
 
 {
-	return (GetCurrentVariant(pDevice) == -1) || (GetCurrentVariant(pDevice) == m_ShotData.GetCount());
+	bool bLastVariantSelected = true;
+	for (int iTry = GetCurrentVariant(pDevice) + 1; iTry < m_ShotData.GetCount(); iTry++)
+		{
+		//  If any variant with higher ID than our current one is valid, then the last variant is NOT currently selected.
+		bLastVariantSelected = bLastVariantSelected && !(VariantIsValid(pSource, pDevice, *m_ShotData[iTry].pDesc));
+		}
+	return ((GetCurrentVariant(pDevice) == -1) || bLastVariantSelected);
 }
 
 bool CWeaponClass::IsSinglePointOrigin (void) const

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -3734,6 +3734,26 @@ bool CWeaponClass::IsAreaWeapon (CSpaceObject *pSource, CInstalledDevice *pDevic
 	return false;
 	}
 
+bool CWeaponClass::IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice)
+
+//	IsVariantSelected
+//
+//	Returns TRUE if we've selected some variant (i.e., we haven't selected 0xffff)
+
+{
+	return (GetCurrentVariant(pDevice) == -1) || (GetCurrentVariant(pDevice) == 0);
+}
+
+bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice)
+
+//	IsVariantSelected
+//
+//	Returns TRUE if we've selected some variant (i.e., we haven't selected 0xffff)
+
+{
+	return (GetCurrentVariant(pDevice) == -1) || (GetCurrentVariant(pDevice) == m_ShotData.GetCount());
+}
+
 bool CWeaponClass::IsSinglePointOrigin (void) const
 
 //	IsSinglePointOrigin

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -3742,15 +3742,15 @@ bool CWeaponClass::IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevic
 //  TODO: Make sure that this is the first variant WITH AVAILABLE AMMO that is selected.
 //  We can do this by making sure that the previous variant has an ID greater than the current one.
 
-{
+	{
 	bool bFirstVariantSelected = true;
 	for (int iTry = GetCurrentVariant(pDevice) - 1; iTry >= 0; iTry--)
-	{
+		{
 		//  If any variant with lower ID than our current one is valid, then the first variant is NOT currently selected.
 		bFirstVariantSelected = bFirstVariantSelected && !(VariantIsValid(pSource, pDevice, *m_ShotData[iTry].pDesc));
-	}
+		}
 	return ((GetCurrentVariant(pDevice) == -1) || bFirstVariantSelected);
-}
+	}
 
 bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice)
 
@@ -3760,7 +3760,7 @@ bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice
 //  TODO: Make sure that this is the last variant WITH AVAILABLE AMMO that is selected.
 //  We can do this by making sure that the next variant has an ID less than the current one.
 
-{
+	{
 	bool bLastVariantSelected = true;
 	for (int iTry = GetCurrentVariant(pDevice) + 1; iTry < m_ShotData.GetCount(); iTry++)
 		{
@@ -3768,7 +3768,7 @@ bool CWeaponClass::IsLastVariantSelected(CSpaceObject *pSource, CInstalledDevice
 		bLastVariantSelected = bLastVariantSelected && !(VariantIsValid(pSource, pDevice, *m_ShotData[iTry].pDesc));
 		}
 	return ((GetCurrentVariant(pDevice) == -1) || bLastVariantSelected);
-}
+	}
 
 bool CWeaponClass::IsSinglePointOrigin (void) const
 


### PR DESCRIPTION
This pull request enables player ships with multiple launchers installed to cycle through all available launchers when the Tab key is pressed. Tab will now cycle through all available missiles, for all available launchers, instead of only the missiles for one launcher.

As with before, the Tab key selects the next missile for the current launcher, and functions identically if only one launcher is installed. However, if multiple launchers are installed, then when the last missile for the current launcher is selected, Tab will instead select the first missile for the next launcher.