### PR TITLE
Allow select weapons to fire upon certain missiles.

### DIFF
--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -1014,6 +1014,7 @@ class CSpaceObject
 
 #define FLAG_INCLUDE_NON_AGGRESSORS		0x00000001
 #define FLAG_INCLUDE_STATIONS			0x00000002
+#define FLAG_INCLUDE_MISSILES			0x00000004
 		int GetNearestVisibleEnemies (int iMaxEnemies, 
 									  Metric rMaxDist, 
 									  TArray<CSpaceObject *> *pretList, 
@@ -1486,6 +1487,7 @@ class CSpaceObject
 		virtual const CDamageSource &GetDamageSource (void) const { return CDamageSource::Null(); }
 		virtual CWeaponFireDesc *GetWeaponFireDesc (void) { return NULL; }
 		virtual CSpaceObject *GetSecondarySource (void) { return NULL; }
+		virtual bool IsTargetableProjectile (void) const { return true; }
 
 		//	...for ships
 

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -477,6 +477,7 @@ class CInstalledDevice
 		//	properties of the device class
 
 		inline bool CanBeEmpty (void) const { return !m_fCannotBeEmpty; }
+		inline bool CanTargetMissiles (void) const { return m_fCanTargetMissiles; }
 		inline int GetCharges (CSpaceObject *pSource) { return (m_pItem ? m_pItem->GetCharges() : 0); }
 		inline bool GetCycleFireSettings (void) const { return m_fCycleFire; }
 		inline DWORD GetData (void) const { return m_dwData; }
@@ -520,6 +521,7 @@ class CInstalledDevice
 		inline bool IsWorking (void) const { return (IsEnabled() && !IsDamaged() && !IsDisrupted()); }
 		inline bool IsWaiting (void) const { return (m_fWaiting ? true : false); }
 		inline void SetActivateDelay (int iDelay) { m_iActivateDelay = iDelay; }
+		inline void SetCanTargetMissiles (bool bCanTargetMissiles) { m_fCanTargetMissiles = bCanTargetMissiles; }
 		inline void SetCycleFireSettings (bool bCycleFire) { m_fCycleFire = bCycleFire; }
 		inline void SetData (DWORD dwData) { m_dwData = dwData; }
 		inline void SetDeviceSlot (int iDev) { m_iDeviceSlot = iDev; }
@@ -691,5 +693,7 @@ class CInstalledDevice
 		DWORD m_fLinkedFireSelectedVariants : 1;//  If TRUE, lkfSelectedVariant
 		DWORD m_fCycleFire :1;					//	If TRUE, then cycle fire through weapons of same type and linked fire settings
 
-		DWORD m_dwSpare2:8;
+		DWORD m_fCanTargetMissiles:1;			//	If TRUE, then this weapon can fire at hostile missiles as well as ships
+
+		DWORD m_dwSpare2:7;
 	};

--- a/Mammoth/Include/TSEShipAI.h
+++ b/Mammoth/Include/TSEShipAI.h
@@ -309,7 +309,7 @@ class IShipController
 		virtual CSpaceObject *GetTarget (CItemCtx &ItemCtx, DWORD dwFlags = 0) const { return NULL; }
 
 		virtual bool GetThrust (void) = 0;
-		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution) { }
+		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles = false) { }
 		virtual bool IsAngryAt (CSpaceObject *pObj) const { return false; }
 		virtual bool IsPlayer (void) const { return false; }
 		virtual bool IsPlayerBlacklisted (void) const { return false; }

--- a/Mammoth/Include/TSESpaceObjectsEnum.h
+++ b/Mammoth/Include/TSESpaceObjectsEnum.h
@@ -223,17 +223,20 @@ class CVisibleEnemyObjSelector
 		inline bool MatchesCategory (CSpaceObject *pObj) const
 			{
 			return (pObj->GetCategory() == CSpaceObject::catShip
-						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation));
+						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation)
+						|| (m_bIncludeMissiles && (pObj->GetCategory() == CSpaceObject::catMissile && pObj->IsTargetableProjectile())));
 			}
 
 		inline void SetExcludeObj (CSpaceObject *pObj) { m_pExcludeObj = pObj; }
 		inline void SetIncludeStations (bool bValue = true) { m_bIncludeStations = bValue; }
+		inline void SetIncludeMissiles(bool bValue = true) { m_bIncludeMissiles = bValue; }
 
 	private:
 		CPerceptionCalc m_Perception;
 		CSpaceObject *m_pSource = NULL;
 		CSpaceObject *m_pExcludeObj = NULL;
 		bool m_bIncludeStations = false;
+		bool m_bIncludeMissiles = false;
 	};
 
 //	CVisibleAggressorObjSelector
@@ -270,11 +273,13 @@ class CVisibleAggressorObjSelector
 		inline bool MatchesCategory (CSpaceObject *pObj) const
 			{
 			return (pObj->GetCategory() == CSpaceObject::catShip
-						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation));
+						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation)
+						|| (m_bIncludeMissiles && (pObj->GetCategory() == CSpaceObject::catMissile && pObj->IsTargetableProjectile())));
 			}
 
 		inline void SetExcludeObj (CSpaceObject *pObj) { m_pExcludeObj = pObj; }
 		inline void SetIncludeStations (bool bValue = true) { m_bIncludeStations = bValue; }
+		inline void SetIncludeMissiles(bool bValue = true) { m_bIncludeMissiles = bValue; }
 
 	private:
 		CPerceptionCalc m_Perception;
@@ -282,6 +287,7 @@ class CVisibleAggressorObjSelector
 		CSpaceObject *m_pExcludeObj = NULL;
 		int m_iAggressorThreshold = -1;
 		bool m_bIncludeStations = false;
+		bool m_bIncludeMissiles = false;
 	};
 
 //	CVisibleObjSelector
@@ -314,17 +320,20 @@ class CVisibleObjSelector
 		inline bool MatchesCategory (CSpaceObject *pObj) const
 			{
 			return (pObj->GetCategory() == CSpaceObject::catShip
-						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation));
+						|| (m_bIncludeStations && pObj->GetCategory() == CSpaceObject::catStation)
+						|| (m_bIncludeMissiles && (pObj->GetCategory() == CSpaceObject::catMissile && pObj->IsTargetableProjectile())));
 			}
 
 		inline void SetExcludeObj (CSpaceObject *pObj) { m_pExcludeObj = pObj; }
 		inline void SetIncludeStations (bool bValue = true) { m_bIncludeStations = bValue; }
+		inline void SetIncludeMissiles (bool bValue = true) { m_bIncludeMissiles = bValue; }
 
 	private:
 		CPerceptionCalc m_Perception;
 		CSpaceObject *m_pSource = NULL;
 		CSpaceObject *m_pExcludeObj = NULL;
 		bool m_bIncludeStations = false;
+		bool m_bIncludeMissiles = false;
 	};
 
 class CSpaceObjectEnum

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -513,7 +513,9 @@ class CMissile : public TSpaceObjectImpl<OBJID_CMISSILE>
 		//	CSpaceObject virtuals
 
 		virtual CMissile *AsMissile (void) override { return this; }
+		virtual bool CanAttack (void) const override { return m_fTargetable; }
 		virtual bool CanThrust (void) const override { return (m_pDesc->GetManeuverRate() > 0); }
+		virtual bool ClassCanAttack (void) override { return m_fTargetable; }
 		virtual void CreateReflection (const CVector &vPos, int iDirection, CMissile **retpReflection = NULL) override;
 		virtual CString DebugCrashInfo (void) override;
 		virtual void DetonateNow (CSpaceObject *pHit) override;
@@ -539,6 +541,7 @@ class CMissile : public TSpaceObjectImpl<OBJID_CMISSILE>
 		virtual bool IsAngryAt (CSpaceObject *pObj) const override;
 		virtual bool IsInactive (void) const override { return (m_fDestroyOnAnimationDone ? true : false); }
 		virtual bool IsIntangible (void) const override { return ((m_fDestroyOnAnimationDone || IsDestroyed()) ? true : false); }
+		virtual bool IsTargetableProjectile (void) const override { return m_fTargetable; }
 		virtual bool IsUnreal (void) const override { return (IsInactive() || IsSuspended() || IsDestroyed()); }
 		virtual void OnMove (const CVector &vOldPos, Metric rSeconds) override;
 		virtual void PaintLRSForeground (CG32bitImage &Dest, int x, int y, const ViewportTransform &Trans) override;
@@ -597,8 +600,9 @@ class CMissile : public TSpaceObjectImpl<OBJID_CMISSILE>
 		DWORD m_fPassthrough:1;					//	TRUE if shot passed through
 		DWORD m_fPainterFade:1;					//	TRUE if we need to paint a fading painter
 		DWORD m_fFragment:1;					//	TRUE if we're a fragment
+		DWORD m_fTargetable:1;					//	TRUE if we can be targetted
 
-		DWORD m_dwSpareFlags:26;				//	Flags
+		DWORD m_dwSpareFlags:25;				//	Flags
 	};
 
 class CParticleDamage : public TSpaceObjectImpl<OBJID_CPARTICLEDAMAGE>

--- a/Mammoth/Include/TSEWeaponFireDesc.h
+++ b/Mammoth/Include/TSEWeaponFireDesc.h
@@ -515,6 +515,7 @@ class CWeaponFireDesc
         CWeaponFireDesc *GetScaledDesc (int iLevel) const;
         int GetSpecialDamage (SpecialDamageTypes iSpecial, DWORD dwFlags = 0) const;
         inline int GetStealth (void) const { return m_iStealth; }
+        inline bool GetTargetable (void) const { return m_fTargetable; }
         inline FireTypes GetType (void) const { return m_iFireType; }
         inline const CString &GetUNID (void) const { return m_sUNID; }
         inline const SVaporTrailDesc &GetVaporTrail (void) const { return GetOldEffects().VaporTrail; }
@@ -654,7 +655,7 @@ class CWeaponFireDesc
 												//		and OnFragment event.
         DWORD m_fRelativisticSpeed:1;			//	If TRUE, adjust speed to simulate for light-lag
         DWORD m_fTargetRequired:1;				//	If TRUE, do not fragment unless we have a target
-        DWORD m_fSpare7:1;
+        DWORD m_fTargetable:1;					//	If TRUE, and type is 'missile', the weaponFire can be shot at by weapons with canTargetMissiles=true
         DWORD m_fSpare8:1;
 
 		DWORD m_dwSpare:16;

--- a/Mammoth/TSE/CBaseShipAI.cpp
+++ b/Mammoth/TSE/CBaseShipAI.cpp
@@ -748,7 +748,7 @@ CSpaceObject *CBaseShipAI::GetEscortPrincipal (void) const
 		}
 	}
 
-void CBaseShipAI::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution)
+void CBaseShipAI::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles)
 
 //	GetNearestTargets
 //
@@ -771,6 +771,11 @@ void CBaseShipAI::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCt
 		DWORD dwFlags = 0;
 		if (m_AICtx.IsAggressor())
 			dwFlags |= FLAG_INCLUDE_NON_AGGRESSORS;
+
+		//  Include missiles if appropriate
+
+		if (bTargetMissiles)
+			dwFlags |= FLAG_INCLUDE_MISSILES;
 
 		//	First build a list of the nearest enemy ships within
 		//	range of the ship.

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -8,6 +8,7 @@
 #define DEVICE_ID_ATTRIB						CONSTLIT("deviceID")
 #define ITEM_ATTRIB								CONSTLIT("item")
 
+#define PROPERTY_CAN_TARGET_MISSILES			CONSTLIT("canTargetMissiles")
 #define PROPERTY_CAPACITOR      				CONSTLIT("capacitor")
 #define PROPERTY_CYCLE_FIRE 					CONSTLIT("cycleFire")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
@@ -60,7 +61,8 @@ CInstalledDevice::CInstalledDevice (void) :
 		m_fLinkedFireSelected(false),
 		m_fLinkedFireNever(false),
 		m_fLinkedFireSelectedVariants(false),
-		m_fCycleFire(false)
+		m_fCycleFire(false),
+		m_fCanTargetMissiles(false)
 	{
 	}
 
@@ -771,6 +773,7 @@ void CInstalledDevice::ReadFromStream (CSpaceObject &Source, SLoadCtx &Ctx)
 	m_fLinkedFireNever =	((dwLoad & 0x00400000) ? true : false);
 	m_fLinkedFireSelectedVariants = ((dwLoad & 0x00800000) ? true : false);
 	m_fCycleFire =		((dwLoad & 0x01000000) ? true : false);
+	m_fCanTargetMissiles =	((dwLoad & 0x02000000) ? true : false);
 
 	//	Previous versions did not save this flag
 
@@ -1010,7 +1013,15 @@ bool CInstalledDevice::SetProperty (CItemCtx &Ctx, const CString &sName, ICCItem
 
 	//	Figure out what to set
 
-    if (strEquals(sName, PROPERTY_CAPACITOR))
+	if (strEquals(sName, PROPERTY_CAN_TARGET_MISSILES))
+		{
+		if (pValue == NULL || !pValue->IsNil())
+			SetCanTargetMissiles(true);
+		else
+			SetCanTargetMissiles(false);
+		}
+
+    else if (strEquals(sName, PROPERTY_CAPACITOR))
         {
         CSpaceObject *pSource = Ctx.GetSource();
         if (!m_pClass->SetCounter(this, pSource, CDeviceClass::cntCapacitor, pValue->GetIntegerValue()))
@@ -1375,6 +1386,7 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 	dwSave |= (m_fLinkedFireNever ?		0x00400000 : 0);
 	dwSave |= (m_fLinkedFireSelectedVariants ? 0x00800000 : 0);
 	dwSave |= (m_fCycleFire ?			0x01000000 : 0);
+	dwSave |= (m_fCanTargetMissiles ?	0x02000000 : 0);
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	CItemEnhancementStack::WriteToStream(m_pEnhancements, pStream);

--- a/Mammoth/TSE/CMissile.cpp
+++ b/Mammoth/TSE/CMissile.cpp
@@ -255,6 +255,7 @@ ALERROR CMissile::Create (CSystem &System, SShotCreateCtx &Ctx, CMissile **retpM
 	pMissile->m_fPassthrough = false;
 	pMissile->m_fPainterFade = false;
 	pMissile->m_fFragment = ((Ctx.dwFlags & SShotCreateCtx::CWF_FRAGMENT) ? true : false);
+	pMissile->m_fTargetable = Ctx.pDesc->GetTargetable();
 	pMissile->m_dwSpareFlags = 0;
 
 	//	If we've got a detonation interval, then set it up
@@ -1063,6 +1064,7 @@ void CMissile::OnReadFromStream (SLoadCtx &Ctx)
 		m_fPassthrough =	((dwLoad & 0x00000008) ? true : false);
 		m_fPainterFade =	((dwLoad & 0x00000010) ? true : false);
 		m_fFragment =		((dwLoad & 0x00000020) ? true : false);
+		m_fTargetable =		((dwLoad & 0x00000040) ? true : false);
 
 		Ctx.pStream->Read((char *)&m_iSavedRotationsCount, sizeof(DWORD));
 		if (m_iSavedRotationsCount > 0)
@@ -1423,6 +1425,7 @@ void CMissile::OnWriteToStream (IWriteStream *pStream)
 	dwSave |= (m_fPassthrough ? 0x00000008 : 0);
 	dwSave |= (m_fPainterFade ? 0x00000010 : 0);
 	dwSave |= (m_fFragment ?	0x00000020 : 0);
+	dwSave |= (m_fTargetable ?	0x00000040 : 0);
 	pStream->Write((char *)&dwSave, sizeof(DWORD));
 
 	//	Saved rotations

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -664,7 +664,7 @@ bool CShip::CalcDeviceTarget (STargetingCtx &Ctx, CItemCtx &ItemCtx, CSpaceObjec
 
 		else
 			{
-			m_pController->GetWeaponTarget(Ctx, ItemCtx, retpTarget, retiFireSolution);
+			m_pController->GetWeaponTarget(Ctx, ItemCtx, retpTarget, retiFireSolution, pDevice->CanTargetMissiles());
 
 			//	We only fire if we have a target
 

--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -3977,6 +3977,8 @@ int CSpaceObject::GetNearestVisibleEnemies (int iMaxEnemies,
 		{
 		CVisibleObjSelector Selector(this);
 		Selector.SetExcludeObj(pExcludeObj);
+		if (dwFlags & FLAG_INCLUDE_MISSILES)
+			Selector.SetIncludeMissiles();
 
 		return CSpaceObjectEnum::FindNearestEnemyObjs(*pSystem, *this, Range, Selector, *pretList, iMaxEnemies);
 		}
@@ -3984,6 +3986,8 @@ int CSpaceObject::GetNearestVisibleEnemies (int iMaxEnemies,
 		{
 		CVisibleAggressorObjSelector Selector(this);
 		Selector.SetExcludeObj(pExcludeObj);
+		if (dwFlags & FLAG_INCLUDE_MISSILES)
+			Selector.SetIncludeMissiles();
 
 		return CSpaceObjectEnum::FindNearestEnemyObjs(*pSystem, *this, Range, Selector, *pretList, iMaxEnemies);
 		}

--- a/Mammoth/TSE/CWeaponFireDesc.cpp
+++ b/Mammoth/TSE/CWeaponFireDesc.cpp
@@ -74,6 +74,7 @@
 #define SPEED_ATTRIB							CONSTLIT("speed")
 #define STEALTH_ATTRIB							CONSTLIT("stealth")
 #define TARGET_REQUIRED_ATTRIB					CONSTLIT("targetRequired")
+#define TARGETABLE_ATTRIB						CONSTLIT("targetable")
 #define TRAIL_ATTRIB							CONSTLIT("trail")
 #define FIRE_TYPE_ATTRIB						CONSTLIT("type")
 #define VAPOR_TRAIL_ATTRIB						CONSTLIT("vaporTrail")
@@ -1579,6 +1580,7 @@ void CWeaponFireDesc::InitFromDamage (const DamageDesc &Damage)
 	m_fNoStationHits = false;
 	m_fNoImmobileHits = false;
 	m_fNoShipHits = false;
+	m_fTargetable = false;
 
 	//	Load missile speed
 
@@ -2229,6 +2231,10 @@ ALERROR CWeaponFireDesc::InitFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, c
 		if (error = m_Events.InitFromXML(Ctx, pEventsDesc))
 			return error;
 		}
+
+	//  Targetability
+
+	m_fTargetable = pDesc->GetAttributeBool(TARGETABLE_ATTRIB);
 
 	return NOERROR;
 	}

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -38,6 +38,7 @@
 #define PROPERTY_CAN_BE_DAMAGED					CONSTLIT("canBeDamaged")
 #define PROPERTY_CAN_BE_DISABLED				CONSTLIT("canBeDisabled")
 #define PROPERTY_CAN_BE_DISRUPTED				CONSTLIT("canBeDisrupted")
+#define PROPERTY_CAN_TARGET_MISSILES			CONSTLIT("canTargetMissiles")
 #define PROPERTY_CAPACITOR      				CONSTLIT("capacitor")
 #define PROPERTY_CYCLE_FIRE 					CONSTLIT("cycleFire")
 #define PROPERTY_DEVICE_SLOTS					CONSTLIT("deviceSlots")
@@ -479,6 +480,8 @@ ICCItem *CDeviceClass::FindItemProperty (CItemCtx &Ctx, const CString &sName)
         return (pDevice ? CC.CreateBool(pDevice->CanBeDisabled(Ctx)) : CC.CreateBool(CanBeDisabled(Ctx)));
 	else if (strEquals(sName, PROPERTY_CAN_BE_DISRUPTED))
 		return (pDevice ? CC.CreateBool(pDevice->CanBeDisrupted()) : CC.CreateBool(CanBeDisrupted()));
+	else if (strEquals(sName, PROPERTY_CAN_TARGET_MISSILES))
+		return (pDevice ? CC.CreateBool(pDevice->CanTargetMissiles()) : CC.CreateNil());
     else if (strEquals(sName, PROPERTY_CAPACITOR))
         {
         CSpaceObject *pSource = Ctx.GetSource();

--- a/Mammoth/TSE/ShipAIImpl.h
+++ b/Mammoth/TSE/ShipAIImpl.h
@@ -339,7 +339,7 @@ class CBaseShipAI : public IShipController
 		virtual bool GetStopThrust (void) override { return false; }
 		virtual CSpaceObject *GetTarget (CItemCtx &ItemCtx, DWORD dwFlags = 0) const override;
 		virtual bool GetThrust (void) override { return m_AICtx.GetThrust(m_pShip); }
-		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution) override;
+		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles = false) override;
 		virtual bool IsAngryAt (CSpaceObject *pObj) const override;
 		virtual bool IsPlayerBlacklisted (void) const override { return (m_fPlayerBlacklisted ? true : false); }
 		virtual bool IsPlayerWingman (void) const override { return (m_fIsPlayerWingman ? true : false); }

--- a/Transcendence/Transcendence/IntroSession.h
+++ b/Transcendence/Transcendence/IntroSession.h
@@ -165,7 +165,7 @@ class CIntroShipController : public IShipController
 		virtual bool GetStopThrust (void) override { return m_pDelegate->GetStopThrust(); }
 		virtual CSpaceObject *GetTarget (CItemCtx &ItemCtx, DWORD dwFlags) const override { return m_pDelegate->GetTarget(ItemCtx, dwFlags); }
 		virtual bool GetThrust (void) override { return m_pDelegate->GetThrust(); }
-		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution) override { m_pDelegate->GetWeaponTarget(TargetingCtx, ItemCtx, retpTarget, retiFireSolution); }
+		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles = false) override { m_pDelegate->GetWeaponTarget(TargetingCtx, ItemCtx, retpTarget, retiFireSolution); }
 		virtual bool IsAngryAt (CSpaceObject *pObj) const override { return m_pDelegate->IsAngryAt(pObj); }
 		virtual int SetAISettingInteger (const CString &sSetting, int iValue) override { return m_pDelegate->SetAISettingInteger(sSetting, iValue); }
 		virtual CString SetAISettingString (const CString &sSetting, const CString &sValue) override { return m_pDelegate->SetAISettingString(sSetting, sValue); }

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -632,7 +632,7 @@ IShipController::OrderTypes CPlayerShipController::GetOrder (int iIndex, CSpaceO
 		}
 	}
 
-void CPlayerShipController::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution)
+void CPlayerShipController::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles)
 
 //	GetNearestTargets
 //
@@ -657,12 +657,14 @@ void CPlayerShipController::GetWeaponTarget (STargetingCtx &TargetingCtx, CItemC
 
 		//	Get other targets
 
+		DWORD dwFlags = bTargetMissiles ? (FLAG_INCLUDE_NON_AGGRESSORS | FLAG_INCLUDE_STATIONS | FLAG_INCLUDE_MISSILES)
+			: (FLAG_INCLUDE_NON_AGGRESSORS | FLAG_INCLUDE_STATIONS);
 		int iMaxTargets = 10;
 		m_pShip->GetNearestVisibleEnemies(iMaxTargets,
 				MAX_AUTO_TARGET_DISTANCE,
 				&TargetingCtx.Targets,
 				pMainTarget,
-				FLAG_INCLUDE_NON_AGGRESSORS | FLAG_INCLUDE_STATIONS);
+				dwFlags);
 
 		TargetingCtx.bRecalcTargets = false;
 		}

--- a/Transcendence/Transcendence/PlayerShip.h
+++ b/Transcendence/Transcendence/PlayerShip.h
@@ -202,7 +202,7 @@ class CPlayerShipController : public IShipController
 		virtual int GetOrderCount (void) const override { return (m_iOrder == IShipController::orderNone ? 0 : 1); }
 		virtual bool GetDeviceActivate (void) override;
 		virtual int GetFireDelay (void) override { return mathRound(5.0 / STD_SECONDS_PER_UPDATE); }
-		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution) override;
+		virtual void GetWeaponTarget (STargetingCtx &TargetingCtx, CItemCtx &ItemCtx, CSpaceObject **retpTarget, int *retiFireSolution, bool bTargetMissiles = false) override;
 		virtual bool IsAngryAt (CSpaceObject *pObj) const override;
 		virtual bool IsPlayer (void) const override { return true; }
 		virtual void ReadFromStream (SLoadCtx &Ctx, CShip *pShip) override;


### PR DESCRIPTION
This change adds a new property for weapons: 'CanTargetMissiles', as well
as a 'targetable' attribute for weaponFire. Weapons with the
'CanTargetMissiles' property can fire at projectiles that have
'targetable' set as true.

Note that in TSEDevices.h, we use one of the remaining 8 "spare bits" of `m_dwSpare2` instead of `m_fSpare5, m_fSpare6, m_fSpare7, m_fSpare8` for the `CanTargetMissiles` property. This is because pull request #13 uses those spare bits.