### PR TITLE
Added new event: GetAmmoCountToDisplay.

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -108,7 +108,8 @@ class CCyberDeckClass : public CDeviceClass
 											 CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
-											 CItemType **retpType = NULL) override;
+											 CItemType **retpType = NULL,
+											 bool bUseCustomAmmoCountHandler = false) override;
 		virtual int GetValidVariantCount (CSpaceObject *pSource, CInstalledDevice *pDevice) override { return 1; }
 		virtual int GetWeaponEffectiveness (CSpaceObject *pSource, CInstalledDevice *pDevice, CSpaceObject *pTarget) override;
 		virtual bool IsFirstVariantSelected(CSpaceObject *pSource, CInstalledDevice *pDevice) override { return true; }
@@ -569,8 +570,9 @@ class CWeaponClass : public CDeviceClass
 			{
 			evtOnFireWeapon				= 0,
 			evtGetAmmoToConsume			= 1,
+			evtGetAmmoCountToDisplay	= 2,
 
-			evtCount					= 2,
+			evtCount					= 3,
 			};
 
         struct SBalance
@@ -681,7 +683,8 @@ class CWeaponClass : public CDeviceClass
 											 CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
-											 CItemType **retpType = NULL) override;
+											 CItemType **retpType = NULL,
+											 bool bUseCustomAmmoCountHandler = false) override;
 		virtual Metric GetShotSpeed (CItemCtx &Ctx) const override;
 		virtual int GetValidVariantCount (CSpaceObject *pSource, CInstalledDevice *pDevice) override;
 		virtual int GetWeaponEffectiveness (CSpaceObject *pSource, CInstalledDevice *pDevice, CSpaceObject *pTarget) override;

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -283,7 +283,8 @@ class CDeviceClass
 											 CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
-											 CItemType **retpType = NULL) { if (retsLabel) *retsLabel = NULL_STR; if (retiAmmoLeft) *retiAmmoLeft = -1; if (retpType) *retpType = NULL; }
+											 CItemType **retpType = NULL,
+											 bool bUseCustomAmmoCountHandler = false) { if (retsLabel) *retsLabel = NULL_STR; if (retiAmmoLeft) *retiAmmoLeft = -1; if (retpType) *retpType = NULL; }
 		virtual Metric GetShotSpeed (CItemCtx &Ctx) const { return 0.0; }
 		virtual void GetStatus (CInstalledDevice *pDevice, CSpaceObject *pSource, int *retiStatus, int *retiMaxStatus) { *retiStatus = 0; *retiMaxStatus = 0; }
 		virtual int GetValidVariantCount (CSpaceObject *pSource, CInstalledDevice *pDevice) { return 0; }

--- a/Mammoth/TSE/CCyberDeckClass.cpp
+++ b/Mammoth/TSE/CCyberDeckClass.cpp
@@ -155,7 +155,8 @@ void CCyberDeckClass::GetSelectedVariantInfo (CSpaceObject *pSource,
 											  CInstalledDevice *pDevice,
 											  CString *retsLabel,
 											  int *retiAmmoLeft,
-											  CItemType **retpType)
+											  CItemType **retpType,
+											  bool bUseCustomAmmoCountHandler)
 
 //	GetSelectedVariantInfo
 //

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -2558,7 +2558,7 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice)
 							//  If it is an ammo weapon, but does not require items, then it is a charges weapon. Add its ammo to the count.
 							{
 							int iAmmoLeft = 0;
-							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft);
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, NULL, true);
 							iAmmoCount += iAmmoLeft;
 							}
 
@@ -2569,7 +2569,7 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons(CInstalledDevice *pDevice)
 							bool ammoIsAdded = false;
 							int iAmmoLeft = 0;
 							CItemType *pAmmoType;
-							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, &pAmmoType);
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, &pAmmoType, true);
 							AmmoItemTypes.Find(pAmmoType, &ammoIsAdded);
 							if (!ammoIsAdded)
 								{

--- a/Mammoth/TSUI/CWeaponHUDCircular.cpp
+++ b/Mammoth/TSUI/CWeaponHUDCircular.cpp
@@ -284,7 +284,7 @@ void CWeaponHUDCircular::PaintWeaponStatus (CShip *pShip, CInstalledDevice *pDev
 
 	CString sVariant;
 	int iAmmoLeft;
-	pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft);
+	pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, true);
 	int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
 	if (iSelectedFireAmmoLeft >= 0)
 		iAmmoLeft = iSelectedFireAmmoLeft;

--- a/Mammoth/TSUI/CWeaponHUDDefault.cpp
+++ b/Mammoth/TSUI/CWeaponHUDDefault.cpp
@@ -146,7 +146,7 @@ void CWeaponHUDDefault::PaintDeviceStatus (CShip *pShip, DeviceNames iDev, int x
 
 		CString sVariant;
 		int iAmmoLeft;
-		pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft);
+		pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, true);
 		int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
 		if (iSelectedFireAmmoLeft >= 0)
 			iAmmoLeft = iSelectedFireAmmoLeft;


### PR DESCRIPTION
 This event enables us to have the UI display a custom amount of ammunition remaining. This displayed amount will not affect anything else that uses the ammo count (i.e. whether or not the weapon can fire, or any tlisp function that returns the amount of ammunition remaining), as it will not change the actual ammo count.

Using Nil as the return to GetAmmoCountToDisplay will use instead the ammo count that would have been used had the event not been called (if any).