### PR TITLE
Improve AI gun targeting for targetable missiles.

### DIFF
--- a/Mammoth/Include/TSESpaceObjectsEnum.h
+++ b/Mammoth/Include/TSESpaceObjectsEnum.h
@@ -214,6 +214,7 @@ class CVisibleEnemyObjSelector
 			return (Obj.CanAttack()
 				&& m_Source.IsAngryAt(&Obj)
 				&& m_Perception.CanBeTargeted(&Obj, rDist2)
+				&& !Obj.IsUnreal()
 				&& !Obj.IsDestroyed()
 				&& &Obj != &m_Source
 				&& &Obj != m_pExcludeObj
@@ -263,6 +264,7 @@ class CVisibleAggressorObjSelector
 			return (Obj.CanAttack()
 				&& m_Source.IsAngryAt(&Obj)
 				&& m_Perception.CanBeTargeted(&Obj, rDist2)
+				&& !Obj.IsUnreal()
 				&& !Obj.IsDestroyed()
 				&& &Obj != &m_Source
 				&& &Obj != m_pExcludeObj
@@ -312,6 +314,7 @@ class CVisibleObjSelector
 			return (Obj.CanAttack()
 				&& m_Perception.CanBeTargeted(&Obj, rDist2)
 				&& !Obj.IsDestroyed()
+				&& !Obj.IsUnreal()
 				&& &Obj != &m_Source
 				&& &Obj != m_pExcludeObj
 				&& !Obj.IsEscortingFriendOf(&m_Source));

--- a/Mammoth/Include/TSESpaceObjectsEnum.h
+++ b/Mammoth/Include/TSESpaceObjectsEnum.h
@@ -313,8 +313,8 @@ class CVisibleObjSelector
 			{
 			return (Obj.CanAttack()
 				&& m_Perception.CanBeTargeted(&Obj, rDist2)
-				&& !Obj.IsDestroyed()
 				&& !Obj.IsUnreal()
+				&& !Obj.IsDestroyed()
 				&& &Obj != &m_Source
 				&& &Obj != m_pExcludeObj
 				&& !Obj.IsEscortingFriendOf(&m_Source));

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -524,6 +524,7 @@ class CMissile : public TSpaceObjectImpl<OBJID_CMISSILE>
 		virtual CString GetDamageCauseNounPhrase (DWORD dwFlags) override { return m_Source.GetDamageCauseNounPhrase(dwFlags); }
 		virtual const CDamageSource &GetDamageSource (void) const override { return m_Source; }
 		virtual int GetInteraction (void) const override { return m_pDesc->GetInteraction(); }
+		virtual int GetLastFireTime (void) const override;
 		virtual int GetLevel (void) const override { return m_pDesc->GetLevel(); }
 		virtual Metric GetMaxSpeed (void) override { return m_pDesc->GetRatedSpeed(); }
 		virtual CString GetNamePattern (DWORD dwNounPhraseFlags = 0, DWORD *retdwFlags = NULL) const override;

--- a/Mammoth/TSE/CMissile.cpp
+++ b/Mammoth/TSE/CMissile.cpp
@@ -501,6 +501,18 @@ CSpaceObject::Categories CMissile::GetCategory (void) const
 	return ((m_pDesc->GetFireType() == CWeaponFireDesc::ftBeam || m_pDesc->GetInteraction() < MIN_MISSILE_INTERACTION) ? catBeam : catMissile);
 	}
 
+int CMissile::GetLastFireTime (void) const
+
+//	GetLastFireTime
+//
+//	Returns 'last fire time', which is 0 if missile is not targetable, or current time if it is.
+
+	{
+	if (IsTargetableProjectile())
+		return GetUniverse().GetTicks();
+	return 0;
+	}
+
 int CMissile::GetManeuverRate (void) const
 
 //	GetManeuverRate


### PR DESCRIPTION
This PR comprises 2 changes. Firstly, all targetable missiles will
have lastFireTime equal to the current time, so that they will be
considered aggressors by AI point defenses (and so fired upon on sight).
Additionally, object finder classes will no longer consider "unreal"
objects, so that AI ships may avoid targeting missiles that are currently
fading out (since those objects are not considered 'destroyed' by the
engine).