### PR TITLE
Enable "flash" shield effects, as well as TLisp for procedural shield hit effects

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -519,6 +519,7 @@ class CShieldClass : public CDeviceClass
 		int m_iIdlePowerUse;					//	Power used to maintain shields
 		DamageTypeSet m_WeaponSuppress;			//	Types of weapons suppressed
 		DamageTypeSet m_Reflective;				//	Types of damage reflected
+		int m_iTimeBetweenFlashEffects;			//  Minimum time between flash effects in ticks
 
 		int m_iExtraHPPerCharge;				//	Extra HP for each point of charge
 		int m_iExtraPowerPerCharge;				//	Extra power use for each point of charge (1/10 megawatt)

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -535,7 +535,8 @@ class CShieldClass : public CDeviceClass
 
 		SEventHandlerDesc m_CachedEvents[evtCount];		//	Cached events
 
-		CEffectCreatorRef m_pHitEffect;			//	Effect when shield is hit
+		CEffectCreatorRef m_pHitEffect;				//	Effect when shield is hit, appearing at hit location
+		CEffectCreatorRef m_pFlashEffect;			//	Effect when shield is hit, appearing on ship
 	};
 
 class CSolarDeviceClass : public CDeviceClass

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -461,6 +461,7 @@ class CShieldClass : public CDeviceClass
 		virtual ALERROR OnDesignLoadComplete (SDesignLoadCtx &Ctx) override;
 		virtual CEffectCreator *OnFindEffectCreator (const CString &sUNID) override;
 		virtual void OnInstall (CInstalledDevice *pDevice, CSpaceObject *pSource, CItemListManipulator &ItemList) override;
+		virtual void PaintHitEffect(CInstalledDevice *pDevice, CSpaceObject *pShip, SDamageCtx &DamageCtx, bool FlashEffect = false);
 		virtual void Recharge (CInstalledDevice *pDevice, CShip *pShip, int iStatus) override;
 		virtual bool RequiresItems (void) const override;
 		virtual void Reset (CInstalledDevice *pDevice, CSpaceObject *pSource) override;

--- a/Mammoth/TSE/CShieldClass.cpp
+++ b/Mammoth/TSE/CShieldClass.cpp
@@ -28,6 +28,7 @@
 #define REGEN_ADJ_PER_CHARGE_ATTRIB				CONSTLIT("regenHPBonusPerCharge")
 #define REGEN_TIME_ATTRIB						CONSTLIT("regenTime")
 #define REGEN_TYPE_ATTRIB						CONSTLIT("regenType")
+#define TIME_BETWEEN_FLASH_EFFECTS_ATTRIB		CONSTLIT("timeBetweenFlashEffects")
 #define WEAPON_SUPPRESS_ATTRIB					CONSTLIT("weaponSuppress")
 
 #define GET_MAX_HP_EVENT						CONSTLIT("GetMaxHP")
@@ -360,9 +361,11 @@ bool CShieldClass::AbsorbDamage (CInstalledDevice *pDevice, CSpaceObject *pShip,
 
 	if ((Ctx.iAbsorb || Ctx.IsShotReflected())
 		&& m_pFlashEffect
-		&& !Ctx.bNoHitEffect)
+		&& !Ctx.bNoHitEffect
+		&& pDevice->IsReady())
 	{
 		PaintHitEffect(pDevice, pShip, Ctx, true);
+		pDevice->SetTimeUntilReady(m_iTimeBetweenFlashEffects);
 	}
 
 	//	Shield takes damage
@@ -874,6 +877,7 @@ ALERROR CShieldClass::CreateFromXML (SDesignLoadCtx &Ctx, SInitCtx &InitCtx, CXM
 		pDesc->GetContentElementByTag(FLASH_EFFECT_TAG),
 		pDesc->GetAttribute(FLASH_EFFECT_ATTRIB)))
 		return error;
+	pShield->m_iTimeBetweenFlashEffects = pDesc->GetAttributeInteger(TIME_BETWEEN_FLASH_EFFECTS_ATTRIB);
 
 	//	Done
 


### PR DESCRIPTION
This PR adds two new features for shield hit effects.

The first involves `flashEffect`s, which can be defined using either the `<FlashEffect>` tag or the `FlashEffect` field just like current `hitEffect`s. The main difference is that these are generated at the ship position, rather than hit position.

The second involves using painters for shield hit effects. This enables us to use TLisp to procedurally generate shield hit effects based on certain variables, e.g. damage of incoming fire, remaining shield HP, etc.