### PR TITLE
Improve Explorer Auton

### DIFF
--- a/Transcendence/TransCore/StdAutons.xml
+++ b/Transcendence/TransCore/StdAutons.xml
@@ -748,14 +748,7 @@
 					(block (
 						;	Look for the nearest unknown object
 						
-						(targetObj (@
-							(filter (sysFindObject gSource "Ts -uncharted; S:d;") theObj
-								(and (not (objIsKnown theObj))
-										(objGetProperty theObj 'hasDockingPorts)
-										(or (objGetProperty theObj 'canBeAttacked) (objMatches theObj gSource "G"))
-										)
-								)
-							0))
+						(targetObj (ObjFireEvent gSource 'GetExploreTarget))
 						)
 						
 						(switch
@@ -781,6 +774,10 @@
 		</Communications>
 
 		<Events>
+			<GetExploreTarget>
+				(sysFindObject gSource "NsT +property:showMapLabel; -property:known; -uncharted;")
+			</GetExploreTarget>
+			
 			<OnOrdersCompleted>
 				(block (behavior theTarget)
 					(setq behavior (objGetData gSource 'behavior))
@@ -794,14 +791,7 @@
 								
 								;	Look for the nearest unknown object
 						
-								(targetObj (@
-									(filter (sysFindObject gSource "Ts -uncharted; S:d;") theObj
-										(and (not (objIsKnown theObj))
-												(objGetProperty theObj 'hasDockingPorts)
-												(or (objCanAttack theObj) (objMatches theObj gSource "G"))
-												)
-										)
-									0))
+								(targetObj (ObjFireEvent gSource 'GetExploreTarget))
 								)
 								
 								;	Explore object


### PR DESCRIPTION
- Now actually fixes the bug with not finding stations that can't attack by checking the same set of ships and stations after exploring one as it does when first issued the explore order.

- Using showMapLabel property excludes satellite stations such as Arcology segments and Sung defense turrets, slave quarters, and defense towers. It also excludes some stations in major clusters, especially near the Battle Arena. This may be undesireable, but shouldn't be a major problem because the main station in a cluster will be found if it wasn't set known at the start of the game. The galaxy map list avoids excluding these by checking whether the type normally shows a map label, but this doesn't seem to be possible in TLisp.