### PR TITLE
Assign auton items with armor damage repairIDs for use by auton bay

### DIFF
--- a/Transcendence/TransCore/RPGAutons.xml
+++ b/Transcendence/TransCore/RPGAutons.xml
@@ -300,7 +300,16 @@
 					(autonItem (itmCreate autonType 1))
 					(shieldMaxHP (shpGetShieldMaxHitPoints gSource))
 					(shieldDamage (shpGetShieldDamage gSource))
+					armorDamaged
+					repairID
 					)
+					
+					;	Assign a repair ID if there's any armor damage
+					
+					(enum (objGetItems gSource "aI") theArmor
+						(if (gr (objGetArmorDamage gSource theArmor) 0) (setq armorDamaged True))
+						)
+					(if armorDamaged (setq repairID (rpgGetNextAutonRepairID)))
 						
 					;	Store the current armor and devices on the auton
 					
@@ -326,6 +335,8 @@
 						name: (if (neq (objGetName gSource) (objGetProperty gSource 'name))
 									(rpgSanitizeAutonName (objGetName gSource))
 									)
+									
+						repairID: repairID
 						}))
 						
 					;	Add one charge on the item for every ton of cargo inside the auton
@@ -437,10 +448,7 @@
 					
 					;	Welcome or error message
 					
-					(if (@ gData 'notEnoughSpace)
-						(objSendMessageTranslate sourceObj auton 'ErrNoSpaceToReturn)
-						(objSendMessageTranslate sourceObj auton 'DeployAck)
-						)
+					(objSendMessageTranslate sourceObj auton (or (@ gData 'messageID) 'DeployAck))
 					
 					;	Return the auton created, in case subclasses want to
 					;	modify it.
@@ -467,18 +475,17 @@
 				;	If we returned to a ship or non-gate station, convert back to an item
 				
 				(if (objMatches aGateObj nil "st -stargate;")
-					(block ((autonItem (objFireEvent gSource "ConvertToItem"))
-							(autonShipClass (itmGetStaticData autonItem 'autonShipClass))
-							)
-						(if (gr (itmGetMass autonItem) (objGetCargoSpaceLeft aGateObj))
+					(block (
+						(autonItem (objFireEvent gSource "ConvertToItem"))
+						(autonShipClass (itmGetStaticData autonItem 'autonShipClass))
+						(notEnoughSpace (gr (itmGetMass autonItem) (objGetCargoSpaceLeft aGateObj)))
+						)
+						;	Add to cargo
+						(objAddItem aGateObj autonItem)
 						
-							; If there's not enough space, redeploy with an error message
-							(typFireEvent autonShipClass 'CreateFromItem
-								{ sourceObj:aGateObj type:autonShipClass item:autonItem notEnoughSpace:true }
-								)
-							
-							; Otherwise, add to cargo
-							(objAddItem aGateObj autonItem)
+						;	If there's not enough space, redeploy with an error message
+						(if notEnoughSpace
+							(rpgDeployAutonFromItem aGateObj autonShipClass autonItem 'ErrNoSpaceToReturn)
 							)
 						)
 					)
@@ -644,16 +651,31 @@
 					)
 				))
 				
-			(setq rpgDeployAutonFromItem (lambda (sourceObj autonUNID autonItem)
+			(setq rpgDeployAutonFromItem (lambda (sourceObj autonUNID autonItem messageID)
 				(block Nil
 					;	Let the auton ship class create itself based on the item
 				
-					(typFireEvent autonUNID 'CreateFromItem { sourceObj:sourceObj type:autonUNID item:autonItem })
+					(typFireEvent autonUNID 'CreateFromItem {
+						sourceObj:sourceObj
+						type:autonUNID
+						item:autonItem
+						messageID:messageID
+						})
 				
 					;	Identify and remove the item from the source
 				
 					(itmSetKnown autonItem)
 					(objRemoveItem sourceObj autonItem 1)
+					
+					;	If the item had a repairID, free it
+					
+					(rpgFreeAutonRepairID (@ (itmGetData autonItem 'autonConfig) 'repairID))
+					)
+				))
+			
+			(setq rpgFreeAutonRepairID (lambda (theID)
+				(typSetData &baAutonItemBase; 'freedRepairIDs
+					(append (typGetData &baAutonItemBase; 'freedRepairIDs) theID)
 					)
 				))
 				
@@ -708,6 +730,48 @@
 						)
 					)
 				))
+			
+			(setq rpgGetAutonItemShieldStatus (lambda (theConfig)
+				(block (theStatus)
+					(if (setq theStatus (@ theConfig 'shieldStatus))
+						(block (
+							(regenTime (- (unvGetTick) (@ theStatus 'regenStartTick) ))
+							(hp (+ (@ theStatus 'hp) (* regenTime (@ theStatus 'regen))))
+							(maxHP (@ theStatus 'maxHP))
+							)
+							(if (geq hp maxHP)
+								(setq hp maxHP)
+								(setq hp (int hp))
+								)
+							{
+								hp: hp
+								percent: (divide (* hp 100) maxHP)
+								}
+							)
+							
+						{ percent: 100 }
+						)
+					)
+				))
+			
+			(setq rpgGetNextAutonRepairID (lambda Nil
+				(block (
+					(freedIDs (typGetData &baAutonItemBase; 'freedRepairIDs))
+					nextID
+					)
+					(if freedIDs
+						(block Nil
+							(setq nextID (@ freedIDs 0))
+							(typSetData &baAutonItemBase; 'freedRepairIDs (subset freedIDs 1))
+							)
+						(block Nil
+							(setq nextID (or (typGetData &baAutonItemBase; 'nextRepairID) 1))
+							(typSetData &baAutonItemBase; 'nextRepairID (add nextID 1))
+							)
+						)
+					nextID
+					)
+				))
 				
 			(setq rpgSanitizeAutonName (lambda (theName)
 				(block (tempName newName)
@@ -738,29 +802,6 @@
 					;	Replace empty string with Nil to reset to default name, otherwise return new name.
 					
 					(if (or (not newName) (eq "" (apply cat (split newName " ")))) Nil (strCapitalize newName))
-					)
-				))
-			
-			(setq rpgGetAutonItemShieldStatus (lambda (theConfig)
-				(block (theStatus)
-					(if (setq theStatus (@ theConfig 'shieldStatus))
-						(block (
-							(regenTime (- (unvGetTick) (@ theStatus 'regenStartTick) ))
-							(hp (+ (@ theStatus 'hp) (* regenTime (@ theStatus 'regen))))
-							(maxHP (@ theStatus 'maxHP))
-							)
-							(if (geq hp maxHP)
-								(setq hp maxHP)
-								(setq hp (int hp))
-								)
-							{
-								hp: hp
-								percent: (divide (* hp 100) maxHP)
-								}
-							)
-							
-						{ percent: 100 }
-						)
 					)
 				))
 			


### PR DESCRIPTION
Also, rpgDeployAutonFromItem now optionally accepts a messageID to display when deploying.