### PR TITLE
Make modified autons in stock configuration coalesce with unmodified

### DIFF
--- a/Mammoth/Include/TSEItems.h
+++ b/Mammoth/Include/TSEItems.h
@@ -217,6 +217,7 @@ class CItem
 		void ClearDamaged (void);
 		void ClearDisrupted (void) { if (m_pExtra) m_pExtra->m_dwDisruptedTime = 0; }
 		void ClearEnhanced (void) { m_dwFlags &= ~flagEnhanced; }
+		void ClearExtra (void) { delete m_pExtra; m_pExtra = NULL; }
 		void ClearInstalled (void);
 		static CItem CreateItemByName (CUniverse &Universe, const CString &sName, const CItemCriteria &Criteria, bool bActualName = false);
 		bool IsEqual (const CItem &Item, DWORD dwFlags = 0) const;
@@ -282,7 +283,7 @@ class CItem
 		int GetUnknownIndex (void) const;
 		CItemType *GetUnknownType (void) const;
 		CItemType *GetUnknownTypeIfUnknown (bool bActual = false) const;
-		int GetVariantNumber(void) const { return (m_pExtra ? (int)m_pExtra->m_dwVariantCounter : 0); }
+		int GetVariantNumber (void) const { return (m_pExtra ? (int)m_pExtra->m_dwVariantCounter : 0); }
 		inline bool HasAttribute (const CString &sAttrib) const;
 		bool HasComponents (void) const;
 		bool HasMods (void) const { return (m_pExtra && m_pExtra->m_Mods.IsNotEmpty()); }
@@ -294,6 +295,7 @@ class CItem
         bool IsEmpty (void) const { return (m_pItemType == NULL); }
 		bool IsEnhanced (void) const { return (m_dwFlags & flagEnhanced ? true : false); }
 		bool IsEnhancementEffective (const CItemEnhancement &Enhancement) const;
+		bool IsExtraEmpty (DWORD dwFlags = 0);
 		bool IsInstalled (void) const { return (m_dwInstalled != 0xff); }
 		bool IsKnown (int *retiUnknownIndex = NULL) const;
 		bool IsMarkedForDelete (void) { return (m_dwCount == 0xffff); }

--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -5422,6 +5422,9 @@ ICCItem *fnItemSet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 					break;
 				}
 
+			if (Item.IsExtraEmpty())
+				Item.ClearExtra();
+
 			return CreateListFromItem(Item);
 			}
 

--- a/Mammoth/TSE/CItem.cpp
+++ b/Mammoth/TSE/CItem.cpp
@@ -2457,6 +2457,11 @@ bool CItem::IsExtraEmpty (const SExtra *pExtra, DWORD dwFlags, DWORD dwNow)
 			&& (bIgnoreData || pExtra->m_Data.IsEmpty()));
 	}
 
+bool CItem::IsExtraEmpty (DWORD dwFlags)
+	{
+	return !m_pExtra || IsExtraEmpty(m_pExtra, dwFlags, GetUniverse().GetTicks());
+	}
+
 bool CItem::IsExtraEqual (SExtra *pSrc, DWORD dwFlags) const
 
 //	IsExtraEqual

--- a/Transcendence/TransCore/RPGAutons.xml
+++ b/Transcendence/TransCore/RPGAutons.xml
@@ -107,7 +107,7 @@
 			
 	LANGUAGE
 	
-	Derrived types may define the following language elements:
+	Derived types may define the following language elements:
 	
 	AttackTargetAck: Reply when auton is ordered to attack a valid target.
 	
@@ -180,23 +180,12 @@
 				</OnShow>
 
 				<Invoke>
-					(block (behavior)
-						(setq behavior (objGetData gSource 'behavior))
-						(switch
-							(or (not behavior) (eq behavior 'escorting))
-								(block Nil
-									(objCommunicate gSource gSender 'FormUp)
-									(objSendMessageTranslate gSender gSource 'FormUpAck)
-									)
-
-							(block Nil
-								(objSetData gSource 'behavior 'escorting)
-								(objSendMessageTranslate gSender gSource 'FormUpAck)
-								
-								(shpCancelOrders gSource)
-								(shpOrder gSource 'escort gPlayerShip)
-								)
-							)
+					(block Nil
+						(objSetData gSource 'behavior 'escorting)
+						(objSendMessageTranslate gSender gSource 'FormUpAck)
+						
+						(shpCancelOrders gSource)
+						(shpOrder gSource 'escort gPlayerShip)
 						)
 				</Invoke>
 			</Message>

--- a/Transcendence/TransCore/RPGAutons.xml
+++ b/Transcendence/TransCore/RPGAutons.xml
@@ -300,8 +300,7 @@
 					(autonItem (itmCreate autonType 1))
 					(shieldMaxHP (shpGetShieldMaxHitPoints gSource))
 					(shieldDamage (shpGetShieldDamage gSource))
-					armorDamaged
-					repairID
+					armorDamaged config
 					)
 					
 					;	Assign a repair ID if there's any armor damage
@@ -309,11 +308,10 @@
 					(enum (objGetItems gSource "aI") theArmor
 						(if (gr (objGetArmorDamage gSource theArmor) 0) (setq armorDamaged True))
 						)
-					(if armorDamaged (setq repairID (rpgGetNextAutonRepairID)))
 						
-					;	Store the current armor and devices on the auton
+					;	Store the current armor, devices, and status on the auton
 					
-					(setq autonItem (itmSetData autonItem 'autonConfig {
+					(setq config {
 						armor: (map (objGetItems gSource "aI") theArmor	{
 							item: (itmSetProperty theArmor 'installed Nil)
 							hp: (subtract (itmGetProperty theArmor 'completeHP) (objGetArmorDamage gSource theArmor))
@@ -336,9 +334,13 @@
 									(rpgSanitizeAutonName (objGetName gSource))
 									)
 									
-						repairID: repairID
-						}))
-						
+						repairID: (if armorDamaged (rpgGetNextAutonRepairID))
+						})
+					
+					(if (neq config (rpgGetAutonDefaultConfig autonItem))
+						(setq autonItem (itmSetData autonItem 'autonConfig config))
+						)
+					
 					;	Add one charge on the item for every ton of cargo inside the auton
 					
 					(setq autonItem (itmSetProperty autonItem 'charges
@@ -680,6 +682,14 @@
 				))
 				
 			(setq rpgGetAutonConfig (lambda (autonItem)
+				;	Return the saved config if there is one, otherwise the default for the item type
+				
+				(or (itmGetData autonItem 'autonConfig)
+					(rpgGetAutonDefaultConfig autonItem)
+					)
+				))
+			
+			(setq rpgGetAutonDefaultConfig (lambda (autonItem)
 				;
 				;	We return a struct with the following elements:
 				;
@@ -688,45 +698,31 @@
 				;				item: An item descriptor
 				;				hp: The number of hit points left
 				;
-				;		default: If True, then the auton is identical to its original
-				;				ship class.
-				;
 				;		devices: An array of structs, each struct with the following
 				;				elements:
 				;
 				;				item: An item descriptor
-				
-				(block (savedConfig autonShipClass)
-				
-					(switch
-						;	We've already stored the information, so we just return it.
-						
-						(setq savedConfig (itmGetData autonItem 'autonConfig))
-							savedConfig
-							
-						;	If we have the ship class then we can take information directly
-						;	from it.
-						
-						(setq autonShipClass (itmGetStaticData autonItem 'autonShipClass))
-							{	default: True
-							
-								armor: (map (typGetDataField autonShipClass 'armorItems) Nil theArmor
-									{
-										item: theArmor
-										hp: (itmGetProperty theArmor 'completeHP)
-										}
-									)
+				(block (
+					(autonShipClass (itmGetStaticData autonItem 'autonShipClass))
+					)
+					(if autonShipClass
+						{
+							armor: (map (typGetDataField autonShipClass 'armorItems) Nil theArmor
+								{
+									item: theArmor
+									hp: (itmGetProperty theArmor 'completeHP)
+									}
+								)
 
-								devices: (map (typGetDataField autonShipClass 'deviceItems) Nil theDevice
-									{
-										item: theDevice
-										}
-									)
-								}
-
+							devices: (map (typGetDataField autonShipClass 'deviceItems) Nil theDevice
+								{
+									item: theDevice
+									}
+								)
+							}
+						
 						;	Otherwise, there is nothing we can do.
-
-						Nil
+						
 						)
 					)
 				))

--- a/Transcendence/TransCore/RPGWingmen.xml
+++ b/Transcendence/TransCore/RPGWingmen.xml
@@ -95,7 +95,7 @@
 			
 			<Message id="msgBreakAndAttack" name="Break &amp; attack" key="B">
 				<OnShow>
-					(not (find '(goingHome attackingAtWill) (objGetData gSource 'behavior)))
+					(not (find '(attackingAtWill goingHome) (objGetData gSource 'behavior)))
 				</OnShow>
 				
 				<Invoke>
@@ -109,13 +109,12 @@
 				</OnShow>
 
 				<Invoke>
-					(block (behavior)
-						(setq behavior (objGetData gSource 'behavior))
-						(objSetData gSource 'behavior 'escorting)
-						(if (or (eq behavior 'attackingTarget) (eq behavior 'attackingAtWill))
+					(block Nil
+						(if (find '(attackingTarget attackingAtWill) (objGetData gSource 'behavior))
 							(objSendMessageTranslate gSender gSource 'CancelAttackAck)
 							(objSendMessageTranslate gSender gSource 'FormUpAck)
 							)
+						(objSetData gSource 'behavior 'escorting)
 							
 						(shpCancelOrders gSource)
 						(shpOrder gSource 'follow gPlayerShip)

--- a/Transcendence/TransCore/RPGWingmen.xml
+++ b/Transcendence/TransCore/RPGWingmen.xml
@@ -110,25 +110,15 @@
 
 				<Invoke>
 					(block (behavior)
-						(setq behavior (objGetData gSource "behavior"))
-						(switch
-							(eq behavior 'escorting)
-								(block Nil
-									(objCommunicate gSource gSender 'FormUp)
-									(objSendMessageTranslate gSender gSource 'FormUpAck)
-									)
-
-							(block Nil
-								(objSetData gSource "behavior" 'escorting)
-								(if (or (eq behavior 'attackingTarget) (eq behavior 'attackingAtWill))
-									(objSendMessageTranslate gSender gSource 'CancelAttackAck)
-									(objSendMessageTranslate gSender gSource 'FormUpAck)
-									)
-									
-								(shpCancelOrders gSource)
-								(shpOrder gSource 'follow gPlayerShip)
-								)
+						(setq behavior (objGetData gSource 'behavior))
+						(objSetData gSource 'behavior 'escorting)
+						(if (or (eq behavior 'attackingTarget) (eq behavior 'attackingAtWill))
+							(objSendMessageTranslate gSender gSource 'CancelAttackAck)
+							(objSendMessageTranslate gSender gSource 'FormUpAck)
 							)
+							
+						(shpCancelOrders gSource)
+						(shpOrder gSource 'follow gPlayerShip)
 						)
 				</Invoke>
 			</Message>

--- a/Transcendence/TransCore/StdAutons.xml
+++ b/Transcendence/TransCore/StdAutons.xml
@@ -748,21 +748,21 @@
 					(block (
 						;	Look for the nearest unknown object
 						
-						(targetObj (ObjFireEvent gSource 'GetExploreTarget))
+						(targetObj (objFireEvent gSource 'GetExploreTarget))
 						)
 						
 						(switch
 							;	If no unknown objects, then say so
 
 							(not targetObj)
-								(objSendMessage gSender gSource (objTranslate gSource 'NoExploreTarget))
+								(objSendMessageTranslate gSender gSource 'NoExploreTarget)
 							
 							;	Otherwise, send the auton to the nearest object
 							
 							(block Nil
 								(objSetData gSource 'behavior 'exploring)
 								(objSetData gSource 'targetID (objGetID targetObj))
-								(objSendMessage gSender gSource (objTranslate gSource 'ExploreAck))
+								(objSendMessageTranslate gSender gSource 'ExploreAck)
 								
 								(shpCancelOrders gSource)
 								(shpOrder gSource 'approach targetObj 75)
@@ -813,7 +813,7 @@
 									(not targetObj)
 										(block Nil
 											(objSetData gSource 'behavior 'escorting)
-											(objSendMessage gPlayerShip gSource (objTranslate gSource 'ExplorationDone))
+											(objSendMessageTranslate gPlayerShip gSource 'ExplorationDone)
 											
 											(shpOrder gSource 'escort gPlayerShip)
 											)


### PR DESCRIPTION
Fixes:
[Setting an item's 'installed property to Nil doesn't make it identical to the uninstalled version](https://ministry.kronosaur.com/record.hexm?id=88531)
At least, for the case of itmSetProperty. Cases where actual items are created or changed, like objAddItem and objSetItemProperty already seem to handle it properly. There may be some additional places where we should remove the extra data from items if it's blank, but I'm not aware of it causing any other problems in-game, so I didn't look too hard.