### PR TITLE
Interpolate drawing position to make slowed time smoother.

### DIFF
--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -734,6 +734,7 @@ class CSpaceObject
 		CDesignType *GetOverride (void) { return m_pOverride; }
 		CSpaceObject *GetPlayerShip (void) const { return (m_pSystem ? m_pSystem->GetPlayerShip() : NULL); }
 		const CVector &GetPos (void) const { return m_vPos; }
+		CVector GetDrawPos(const SViewportPaintCtx& Ctx) const { return Ctx.InterpolateForDrawing(GetOldPos(), GetPos()); };
 		CSovereign *GetSovereignToDefend (void) const;
 		DWORD GetSovereignUNID (void) const { CSovereign *pSovereign = GetSovereign(); return (pSovereign ? pSovereign->GetUNID() : 0); }
 		ICCItemPtr GetStaticData (const CString &sAttrib);

--- a/Mammoth/Include/TSEPaint.h
+++ b/Mammoth/Include/TSEPaint.h
@@ -80,6 +80,11 @@ struct SViewportPaintCtx
 				}
 			}
 
+		CVector InterpolateForDrawing(const CVector& vOldPos, const CVector& vPos) const
+			{
+			return vOldPos + dFrameInterpolation * (vPos - vOldPos);
+			}
+
 		//	Viewport metrics
 
 		CSpaceObject *pCenter = NULL;			//	Center object (viewport perspective)
@@ -91,6 +96,8 @@ struct SViewportPaintCtx
 												//		Screen viewport coordinates has positive-Y down.
 		ViewportTransform XFormRel;				//	In the case of effects, this Xform has been translated
 												//		to offset for the effect position
+
+		double dFrameInterpolation;
 
 		CVector vDiagonal;						//	Length of 1/2 viewport diagonal (in global coordinates).
 		CVector vUR;							//	upper-right and lower-left of viewport in global

--- a/Mammoth/Include/TSESystem.h
+++ b/Mammoth/Include/TSESystem.h
@@ -546,7 +546,8 @@ class CSystem
 		CVector OnJumpPosAdj (CSpaceObject *pObj, const CVector &vPos);
 		void OnPlayerChangedShips (CSpaceObject &OldShip, CSpaceObject &NewShip, SPlayerChangedShipsCtx &Options);
 		void OnStationDestroyed (SDestroyCtx &Ctx);
-		void PaintViewport (CG32bitImage &Dest, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags, SViewportAnnotations *pAnnotations = NULL);
+		void PaintViewport (CG32bitImage &Dest, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags,
+	                        double dFrameInterpolation, SViewportAnnotations *pAnnotations = NULL);
 		void PaintViewportGrid (CMapViewportCtx &Ctx, CG32bitImage &Dest, Metric rGridSize);
 		void PaintViewportObject (CG32bitImage &Dest, const RECT &rcView, CSpaceObject *pCenter, CSpaceObject *pObj);
 		void PaintViewportLRS (CG32bitImage &Dest, const RECT &rcView, CSpaceObject *pCenter, Metric rScale, DWORD dwFlags, bool *retbNewEnemies);
@@ -639,7 +640,7 @@ class CSystem
 		CSystem (CUniverse &Universe, CTopologyNode *pTopology);
 
 		CG32bitPixel CalcStarshineColor (CSpaceObject *pPOV, CSpaceObject **retpStar = NULL, const CG8bitSparseImage **retpVolumetricMask = NULL) const;
-		void CalcViewportCtx (SViewportPaintCtx &Ctx, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags);
+		void CalcViewportCtx (SViewportPaintCtx &Ctx, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags, double dFrameInterpolation);
 		void CalcVolumetricMask (CSpaceObject *pStar, CG8bitSparseImage &VolumetricMask);
 		void ComputeStars (void);
 		ALERROR CreateStationInt (SSystemCreateCtx *pCtx,

--- a/Mammoth/Include/TSEUniverse.h
+++ b/Mammoth/Include/TSEUniverse.h
@@ -600,6 +600,7 @@ class CUniverse
 		bool m_bResurrectMode = false;			//	If TRUE, this session is a game resurrect
 		int m_iTick = 1;						//	Ticks since beginning of time
 		int m_iPaintTick = 1;					//	Advances only when we paint a frame
+		double m_dFrameInterpolation = 0.;      //  How far to interpolate between the old and new positions.
 		CDifficultyOptions m_Difficulty;		//	Difficulty level
 		CGameTimeKeeper m_Time;					//	Game time tracker
 		CSpaceObject *m_pPOV = NULL;			//	Point of view

--- a/Mammoth/TSE/CContinuousBeam.cpp
+++ b/Mammoth/TSE/CContinuousBeam.cpp
@@ -504,6 +504,7 @@ void CContinuousBeam::OnPaint (CG32bitImage &Dest, int x, int y, SViewportPaintC
 
 	bool bFoundHead = false;
 	CVector vHead;
+	CVector vOldHead;
 	for (i = 0; i < m_Segments.GetCount(); i++)
 		{
 		SSegment &Segment = m_Segments[i];
@@ -516,6 +517,7 @@ void CContinuousBeam::OnPaint (CG32bitImage &Dest, int x, int y, SViewportPaintC
 			if (Segment.fAlive)
 				{
 				vHead = Segment.vPos;
+				vOldHead = Segment.vPos - Segment.vDeltaPos;
 				bFoundHead = true;
 				}
 			}
@@ -525,7 +527,8 @@ void CContinuousBeam::OnPaint (CG32bitImage &Dest, int x, int y, SViewportPaintC
 
 		else if (!Segment.fAlive)
 			{
-			m_pPainter->PaintLine(Dest, vHead, Segment.vPos, Ctx);
+			m_pPainter->PaintLine(Dest, Ctx.InterpolateForDrawing(vOldHead, vHead),
+				Ctx.InterpolateForDrawing(Segment.vPos - Segment.vDeltaPos, Segment.vPos), Ctx);
 			bFoundHead = false;
 			}
 		}

--- a/Mammoth/TSE/CObjectJoint.cpp
+++ b/Mammoth/TSE/CObjectJoint.cpp
@@ -253,10 +253,10 @@ void CObjectJoint::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) const
 		case jointSpine:
 			{
 			int xFrom, yFrom;
-			Ctx.XForm.Transform(m_P1.pObj->GetPos(), &xFrom, &yFrom);
+			Ctx.XForm.Transform(m_P1.pObj->GetDrawPos(Ctx), &xFrom, &yFrom);
 
 			int xTo, yTo;
-			Ctx.XForm.Transform(m_P2.pObj->GetPos(), &xTo, &yTo);
+			Ctx.XForm.Transform(m_P2.pObj->GetDrawPos(Ctx), &xTo, &yTo);
 
 			Dest.DrawLine(xFrom, yFrom, xTo, yTo, 2, CG32bitPixel(255, 255, 128));
 			break;

--- a/Mammoth/TSE/CParticleArray.cpp
+++ b/Mammoth/TSE/CParticleArray.cpp
@@ -1290,8 +1290,12 @@ void CParticleArray::PaintGaseous (CG32bitImage &Dest,
 
 			//	Compute the position of the particle
 
-			int x = xPos + pParticle->x / FIXED_POINT;
-			int y = yPos + pParticle->y / FIXED_POINT;
+			CVector vPos(pParticle->x, pParticle->y);
+			CVector vOldPos(pParticle->x - pParticle->xVel, pParticle->y - pParticle->yVel);
+			CVector vIntPos= Ctx.InterpolateForDrawing(vOldPos, vPos);
+
+			int x = xPos + int(vIntPos.GetX() / FIXED_POINT);
+			int y = yPos + int(vIntPos.GetY() / FIXED_POINT);
 
 			//	Paint the particle
 

--- a/Mammoth/TSE/CSystem.cpp
+++ b/Mammoth/TSE/CSystem.cpp
@@ -39,6 +39,10 @@ const Metric SAME_POS_THRESHOLD2 =				(g_KlicksPerPixel * g_KlicksPerPixel);
 
 constexpr Metric MAP_GRID_SIZE =				3000.0 * LIGHT_SECOND;
 
+
+extern double start_frame_time;
+extern double frame_duration;
+
 CSystem::CSystem (CUniverse &Universe, CTopologyNode *pTopology) : 
 		m_Universe(Universe),
 		m_dwID(OBJID_NULL),
@@ -491,7 +495,7 @@ CG32bitPixel CSystem::CalcStarshineColor (CSpaceObject *pPOV, CSpaceObject **ret
 	return CG32bitPixel(rgbStarColor, (BYTE)(MAX_SPACE_OPACITY * iPercent / 100));
 	}
 
-void CSystem::CalcViewportCtx (SViewportPaintCtx &Ctx, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags)
+void CSystem::CalcViewportCtx (SViewportPaintCtx &Ctx, const RECT &rcView, CSpaceObject *pCenter, DWORD dwFlags, double dFrameInterpolation)
 
 //	CalcViewportCtx
 //
@@ -501,8 +505,9 @@ void CSystem::CalcViewportCtx (SViewportPaintCtx &Ctx, const RECT &rcView, CSpac
 	DEBUG_TRY
 	ASSERT(pCenter);
 
+	Ctx.dFrameInterpolation = dFrameInterpolation;
 	Ctx.pCenter = pCenter;
-	Ctx.vCenterPos = pCenter->GetPos();
+	Ctx.vCenterPos = pCenter->GetDrawPos(Ctx);
 	Ctx.rcView = rcView;
 	Ctx.vDiagonal = CVector(g_KlicksPerPixel * (Metric)(RectWidth(rcView)) / 2,
 				g_KlicksPerPixel * (Metric)(RectHeight(rcView)) / 2);
@@ -3029,7 +3034,8 @@ void CSystem::PaintDestinationMarker (SViewportPaintCtx &Ctx, CG32bitImage &Dest
 void CSystem::PaintViewport (CG32bitImage &Dest, 
 							 const RECT &rcView, 
 							 CSpaceObject *pCenter, 
-							 DWORD dwFlags, 
+							 DWORD dwFlags,
+	                         double dFrameInterpolation,
 							 SViewportAnnotations *pAnnotations)
 
 //	PaintViewport
@@ -3044,7 +3050,7 @@ void CSystem::PaintViewport (CG32bitImage &Dest,
 	//	Initialize the viewport context
 
 	SViewportPaintCtx Ctx;
-	CalcViewportCtx(Ctx, rcView, pCenter, dwFlags);
+	CalcViewportCtx(Ctx, rcView, pCenter, dwFlags, dFrameInterpolation);
 	Dest.SetClipRect(rcView);
 
 	//	Keep track of the player object because sometimes we do special processing

--- a/Mammoth/TSE/CSystemSpacePainter.cpp
+++ b/Mammoth/TSE/CSystemSpacePainter.cpp
@@ -287,8 +287,8 @@ void CSystemSpacePainter::PaintSpaceBackground (CG32bitImage &Dest, CSystemType 
 		//	parallax offset. It's OK if we overflow an integer (because we want
 		//	to wrap around anyways).
 
-		int xCenter = (int)(Ctx.pCenter->GetPos().GetX() / g_KlicksPerPixel);
-		int yCenter = (int)(Ctx.pCenter->GetPos().GetY() / g_KlicksPerPixel);
+		int xCenter = (int)(Ctx.pCenter->GetDrawPos(Ctx).GetX() / g_KlicksPerPixel);
+		int yCenter = (int)(Ctx.pCenter->GetDrawPos(Ctx).GetY() / g_KlicksPerPixel);
 
 		//	If we have an system background image, paint that.
 
@@ -462,8 +462,8 @@ void CSystemSpacePainter::PaintStarshine (CG32bitImage &Dest, CSystemType *pType
 	//	parallax offset. It's OK if we overflow an integer (because we want
 	//	to wrap around anyways).
 
-	int xCenter = (int)(Ctx.pCenter->GetPos().GetX() / g_KlicksPerPixel);
-	int yCenter = (int)(Ctx.pCenter->GetPos().GetY() / g_KlicksPerPixel);
+	int xCenter = (int)(Ctx.pCenter->GetDrawPos(Ctx).GetX() / g_KlicksPerPixel);
+	int yCenter = (int)(Ctx.pCenter->GetDrawPos(Ctx).GetY() / g_KlicksPerPixel);
 
 	PaintStarshine(Dest, xCenter, yCenter, Ctx);
 	}

--- a/Mammoth/TSE/CUniverse.cpp
+++ b/Mammoth/TSE/CUniverse.cpp
@@ -2135,7 +2135,7 @@ void CUniverse::PaintPOV (CG32bitImage &Dest, const RECT &rcView, DWORD dwFlags)
 	{
 	if (m_pCurrentSystem && m_pPOV)
 		{
-		m_pCurrentSystem->PaintViewport(Dest, rcView, m_pPOV, dwFlags, &m_ViewportAnnotations);
+		m_pCurrentSystem->PaintViewport(Dest, rcView, m_pPOV, dwFlags, m_dFrameInterpolation,  &m_ViewportAnnotations);
 
 		//	Reset annotations until the next update
 
@@ -2287,6 +2287,7 @@ ALERROR CUniverse::Reinit (void)
 
 	m_iTick = 1;
 	m_iPaintTick = 1;
+	m_dFrameInterpolation = 0.;
 
 	//	Clear some basic variables
 
@@ -2837,6 +2838,7 @@ bool CUniverse::Update (SSystemUpdateCtx &Ctx, EUpdateSpeeds iUpdateMode)
 			UpdateTick(Ctx);
 			UpdateTick(Ctx);
 			UpdateTick(Ctx);
+			m_dFrameInterpolation = 0.;
 			m_dwFrame++;
 			return true;
 
@@ -2844,16 +2846,19 @@ bool CUniverse::Update (SSystemUpdateCtx &Ctx, EUpdateSpeeds iUpdateMode)
 			return false;
 
 		case updateSlowMotion:
-			if ((m_dwFrame++ % 4) == 0)
-				{
+		    {
+			bool do_update = (m_dwFrame++ % 4) == 0;
+			if (do_update)
+			    {
 				UpdateTick(Ctx);
-				return true;
-				}
-			else
-				return false;
+			    }
+			m_dFrameInterpolation = ((m_dwFrame - 1) % 4) / 4.;
+			return do_update;
+		    }
 
 		default:
 			UpdateTick(Ctx);
+			m_dFrameInterpolation = 0.;
 			m_dwFrame++;
 			return true;
 		}

--- a/Mammoth/TSE/IPaintList.cpp
+++ b/Mammoth/TSE/IPaintList.cpp
@@ -22,7 +22,7 @@ void CDepthPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) const
 			//	Figure out the position of the object in pixels
 
 			int x, y;
-			Ctx.XForm.Transform(pObj->GetPos(), &x, &y);
+			Ctx.XForm.Transform(pObj->GetDrawPos(Ctx), &x, &y);
 
 			//	Paint the object in the viewport
 
@@ -79,7 +79,7 @@ void CMarkerPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) const
 			//	relative to the center of the screen
 
 			int x, y;
-			Ctx.XForm.Transform(pObj->GetPos(), &x, &y);
+			Ctx.XForm.Transform(pObj->GetDrawPos(Ctx), &x, &y);
 			x = x - Ctx.xCenter;
 			y = y - Ctx.yCenter;
 
@@ -182,7 +182,7 @@ void CParallaxPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) cons
 		//	Figure out the position of the object in pixels
 
 		int x, y;
-		Ctx.XForm.Transform(pObj->GetPos(), &x, &y);
+		Ctx.XForm.Transform(pObj->GetDrawPos(Ctx), &x, &y);
 
 		//	Paint the object in the viewport
 
@@ -201,6 +201,7 @@ void CParallaxPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) cons
 	Ctx.XFormRel = Ctx.XForm;
 	}
 
+
 void CUnorderedPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) const
 
 //	Paint
@@ -217,7 +218,7 @@ void CUnorderedPaintList::Paint (CG32bitImage &Dest, SViewportPaintCtx &Ctx) con
 			//	Figure out the position of the object in pixels
 
 			int x, y;
-			Ctx.XForm.Transform(pObj->GetPos(), &x, &y);
+			Ctx.XForm.Transform(pObj->GetDrawPos(Ctx), &x, &y);
 
 			//	Paint the object in the viewport
 

--- a/Mammoth/TSE/SFXParticleCloud.cpp
+++ b/Mammoth/TSE/SFXParticleCloud.cpp
@@ -632,7 +632,7 @@ void CParticleCloudPainter::Paint (CG32bitImage &Dest, int x, int y, SViewportPa
 	int xPaint;
 	int yPaint;
 	if (m_bUseObjectCenter && Ctx.pObj)
-		Ctx.XForm.Transform(Ctx.pObj->GetPos(), &xPaint, &yPaint);
+		Ctx.XForm.Transform(Ctx.pObj->GetDrawPos(Ctx), &xPaint, &yPaint);
 	else
 		{
 		xPaint = x;

--- a/Mammoth/TSE/SFXParticleSystem.cpp
+++ b/Mammoth/TSE/SFXParticleSystem.cpp
@@ -582,7 +582,9 @@ void CParticleSystemEffectPainter::Paint (CG32bitImage &Dest, int x, int y, SVie
 	if (m_bUseObjectCenter)
 		{
 		if (Ctx.pObj)
-			Ctx.XForm.Transform(Ctx.pObj->GetPos(), &xPaint, &yPaint);
+			{
+			Ctx.XForm.Transform(Ctx.pObj->GetDrawPos(Ctx), &xPaint, &yPaint);
+			}
 		else
 			{
 			//	If we don't have an object then we use the viewport center. This

--- a/Transcendence/Transcendence/PlayerController.cpp
+++ b/Transcendence/Transcendence/PlayerController.cpp
@@ -1712,7 +1712,7 @@ void CPlayerShipController::PaintDebugLineOfFire (SViewportPaintCtx &Ctx, CG32bi
 	if (!pShip->IsLineOfFireClear(&Weapon, NULL, iDir, Max(Weapon.GetMaxEffectiveRange(pShip), DEFAULT_DIST_CHECK), &pBlock))
 		{
 		int x, y;
-		Ctx.XForm.Transform(pBlock->GetPos(), &x, &y);
+		Ctx.XForm.Transform(pBlock->GetDrawPos(Ctx), &x, &y);
 
 		CGDraw::Arc(Dest, x, y, 60, 0, 0, 1, RGB_BLOCKED);
 		}
@@ -1801,7 +1801,7 @@ void CPlayerShipController::PaintTargetingReticle (SViewportPaintCtx &Ctx, CG32b
 
 	{
 	int x, y;
-	Ctx.XForm.Transform(pTarget->GetPos(), &x, &y);
+	Ctx.XForm.Transform(pTarget->GetDrawPos(Ctx), &x, &y);
 
 	CG32bitPixel rgbColor = pTarget->GetSymbolColor();
 	int iSize = 8;


### PR DESCRIPTION
This is WIP, many things are broken but I'd like to know if this is a good enough idea/worth it to pursue it futher.

The idea is simple: use linear interpolation between current and old positions when drawing in slow time (e.g. when invoking Domina powers) to make everything move smoothly despite the slower update rate.

Here it is in action: https://www.youtube.com/watch?v=DR_ZJn3OIZQ

Many things work, but some don't (e.g. for some reason missile trails are broken despite using the same particle system as engine trails which work fine). There are a few bigger issues with this approach:

- It requires hunting down all the locations where we need to interpolate the drawing position
- If any place is missed, it'll look _worse_ than it did before this change, because the viewport position is always interpolated and its essential to cancel this out for moving objects.
- This introduces a 1 frame drawing lag because we're interpolating from old to new.
- Not everything has an 'old position', and estimating it based on velocity is not perfect. This might require making more things track their old position.

Tell me what you think.