### PR TITLE
Fix `burstTracksTargets` repeating weapon aim when target destroyed during burst

### DIFF
--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -1311,6 +1311,7 @@ bool CWeaponClass::CalcSingleTarget (CInstalledDevice &Device,
 
 		if ((IsTracking(DeviceItem, &ShotDesc) || m_bBurstTracksTargets) && !(Source.IsBlind() && !(m_bCanFireWhenBlind)))
 			{
+			bool bCanReacquireTarget = ShotDesc.CanAutoTarget();
 			retpTarget = Device.GetTarget(&Source);
 			retiFireAngle = Device.GetFireAngle();
 
@@ -1324,7 +1325,17 @@ bool CWeaponClass::CalcSingleTarget (CInstalledDevice &Device,
 				}
 			else if (!retpTarget && (retiFireAngle == -1 || m_bBurstTracksTargets))
 				{
-				retiFireAngle = -1;
+				//  Reacquire target if we can do so
+				if (bCanReacquireTarget)
+					retpTarget = CalcBestTarget(Device, ActivateCtx.TargetList, NULL, &retiFireAngle);
+
+				if (retpTarget)
+					{
+					Metric rSpeed = ShotDesc.GetInitialSpeed();
+					retiFireAngle = CalcFireAngle(CItemCtx(&Source, &Device), rSpeed, retpTarget);
+					}
+				else
+				    retiFireAngle = -1;
 				}
 			}
 

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -1322,6 +1322,10 @@ bool CWeaponClass::CalcSingleTarget (CInstalledDevice &Device,
 				Metric rSpeed = ShotDesc.GetInitialSpeed();
 				retiFireAngle = CalcFireAngle(ItemCtx, rSpeed, retpTarget);
 				}
+			else if (!retpTarget && (retiFireAngle == -1 || m_bBurstTracksTargets))
+				{
+				retiFireAngle = -1;
+				}
 			}
 
 		//	No need for a target because we just fire 


### PR DESCRIPTION
Presently, when a gun with `burstTracksTargets` is aiming at a target that
is destroyed during the burst, the gun continues the burst at that given
firing angle regardless of the ship's orientation (even if the firing
angle is outside the gun's fire arc). This fix makes the gun fire down the
default fire angle if the target is destroyed during the burst.