### PR TITLE
Fix guns not shooting at targetable missiles

### DIFF
--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -650,6 +650,11 @@ CSpaceObject *CWeaponClass::CalcBestTarget (CInstalledDevice &Device, const CTar
 	bool bCheckLineOfFire = !TargetList.NoLineOfFireCheck();
 	bool bCheckRange = !TargetList.NoRangeCheck() || (Device.GetMaxFireRangeLS() != 0);
 	DWORD dwTargetTypes = DeviceItem.GetTargetTypes();
+	if (dwTargetTypes & CTargetList::typeMissile)
+		{
+		//  If we can target missiles, then we can target targetable missiles as well
+		dwTargetTypes |= CTargetList::typeTargetableMissile;
+		}
 
 	Metric rMaxRange = DeviceItem.GetMaxEffectiveRange();
 	Metric rMaxRange2 = rMaxRange * rMaxRange;

--- a/Mammoth/TSE/TargetListImpl.h
+++ b/Mammoth/TSE/TargetListImpl.h
@@ -28,7 +28,8 @@ class CTargetListSelector
 						&& m_Source.IsAngryAt(&Obj)
 						&& Obj != m_Options.pExcludeObj)
 					{
-					if (retiType) *retiType = CTargetList::typeMissile;
+					CTargetList::ETargetTypes missileType = Obj.IsTargetableProjectile() ? CTargetList::typeTargetableMissile : CTargetList::typeMissile;
+					if (retiType) *retiType = missileType;
 					return true;
 					}
 				}


### PR DESCRIPTION
Classes `targetableMissile` and `missile` are treated by the engine as separate and different classes when guns are checking what objects they can target. In addition, the code never assigned the class of `targetableMissile` to any object. This change fixes this problem by assigning the `targetableMissile` target category to targetable missiles, and enabling any gun that can target `missiles` to target `targetableMissiles` as well.