### PR TITLE
Stealth and perception enhancements

### DIFF
--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -356,11 +356,11 @@ class CSpaceObject
 			{
 			stealthMin =			0,
 			stealthNormal =			4,
-			stealthMax =			15,			//	Cloaked
+			stealthMax = CPerceptionCalc::EConstants::RANGE_ARRAY_SIZE - 1,			//	Cloaked
 
 			perceptMin =			0,
 			perceptNormal =			4,
-			perceptMax =			15,
+			perceptMax = CPerceptionCalc::EConstants::RANGE_ARRAY_SIZE - 1,
 			};
 
 		enum InterSystemResults

--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -1171,6 +1171,7 @@ class CSpaceObject
 		virtual Metric GetCargoSpaceLeft (void) const { return 1000000.0; }
 		virtual int GetCombatPower (void) { return 0; }
 		virtual int GetCounterIncrementRate (void) const { return 0; }
+		virtual bool GetCounterIsHeat (void) const { return false; }
 		virtual int GetCounterValue (void) const { return 0; }
 		virtual int GetCyberDefenseLevel (void) const { return GetLevel(); }
 		virtual int GetDamageEffectiveness (CSpaceObject *pAttacker, CInstalledDevice *pWeapon) { return 0; }
@@ -1184,7 +1185,7 @@ class CSpaceObject
 		virtual int GetLastFireTime (void) const { return 0; }
 		virtual int GetLastHitTime (void) const { return 0; }
 		virtual int GetLevel (void) const { return 1; }
-		virtual int GetMaxCounterValue(void) { return 0; }
+		virtual int GetMaxCounterValue (void) const { return 0; }
 		virtual int GetMaxPower (void) const { return 0; }
 		virtual int GetMaxLightDistance (void) const { return 0; }
 		virtual Metric GetMaxWeaponRange (void) const { return 0.0; }
@@ -1196,6 +1197,8 @@ class CSpaceObject
 		virtual int GetShieldLevel (void) const { return -1; }
 		virtual CG32bitPixel GetSpaceColor (void) { return 0; }
 		virtual int GetStealth (void) const { return stealthNormal; }
+		virtual int GetStealthAdj(void) const { return 0; }
+		virtual int GetStealthAdjAtMaxHeat(void) const { return 0; }
 		virtual int GetVisibleDamage (void) { return 0; }
 		virtual void GetVisibleDamageDesc (SVisibleDamage &Damage) const { Damage = SVisibleDamage(); }
 		virtual void IncCounterValue(int iCounterValue) { }

--- a/Mammoth/Include/TSEArmor.h
+++ b/Mammoth/Include/TSEArmor.h
@@ -64,7 +64,7 @@ class CArmorClass
 		int GetMaxHPBonus (void) const { return m_iMaxHPBonus; }
 		inline CString GetName (void) const;
 		CString GetShortName (void);
-		int GetStealth (void) const { return m_iStealth; }
+		int GetStealth (void) const { return m_iStealthFromArmor; }
 		DWORD GetUNID (void);
 		bool IsScalable (void) const { return (m_pScalable != NULL); }
 		ALERROR OnBindDesign (SDesignLoadCtx &Ctx);
@@ -166,7 +166,7 @@ class CArmorClass
 		int m_iRepairTech;						//	Tech required to repair
 		int m_iArmorCompleteBonus;				//	Extra HP if armor is complete
 		int m_iHPBonusPerCharge;				//	Extra HP for each charge
-		int m_iStealth;							//	Stealth level
+		int m_iStealthFromArmor;							//	Stealth level
 		int m_iPowerUse;						//	Power consumed (1/10th MWs)
 		int m_iIdlePowerUse;					//	Power consumed when not regenerating
 		int m_iPowerGen;						//	Power generation, usually solar (1/10th MWs)

--- a/Mammoth/Include/TSEShipClass.h
+++ b/Mammoth/Include/TSEShipClass.h
@@ -164,6 +164,8 @@ class CHullDesc
 		int GetMaxReactorPower (void) const { return m_iMaxReactorPower; }
 		int GetMaxWeapons (void) const { return m_iMaxWeapons; }
 		int GetSize (void) const { return m_iSize; }
+		int GetStealthAdj (void) const { return m_iStealthAdj; }
+		int GetStealthAdjAtMaxHeat (void) const { return m_iStealthAdjAtMaxHeat; }
 		const CCurrencyAndValue &GetValue (void) const { return m_Value; }
 		bool HasArmorLimits (void) const { return m_ArmorLimits.HasArmorLimits(); }
 		bool IsImmuneTo (SpecialDamageTypes iSpecialDamage) const;
@@ -187,6 +189,8 @@ class CHullDesc
 		CCurrencyAndValue m_Value;			//	Value of hull alone (excluding any devices/armor)
 		int m_iCargoSpace = 0;				//	Default cargo space (tons)
 		int m_iCounterIncrementRate = 0;	//  Value by which temperature/capacitor counter is updated every tick
+		int m_iStealthAdj = 0;				//  Stealth value of the ship at zero heat to add to armor/nebula stealth value
+		int m_iStealthAdjAtMaxHeat = 0;		//  Stealth value of the ship at max heat to add to armor/nebula stealth value
 
 		CItemCriteria m_DeviceCriteria;		//	Allowable devices
 		CArmorLimits m_ArmorLimits;			//	Adjustments based on armor

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1137,6 +1137,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		virtual int GetCombatPower (void) override;
 		virtual int GetCounterValue (void) const override { return m_iCounterValue; }
 		virtual int GetCounterIncrementRate (void) const override { return m_pClass->GetHullDesc().GetCounterIncrementRate(); }
+		virtual bool GetCounterIsHeat (void) const override { return m_pClass->GetHullDesc().GetCounterIncrementRate() < 0; }
 		virtual const CCurrencyBlock *GetCurrencyBlock (void) const override;
 		virtual CCurrencyBlock *GetCurrencyBlock (bool bCreate = false) override;
 		virtual int GetCyberDefenseLevel (void) const override { return m_pClass->GetCyberDefenseLevel(); }
@@ -1164,7 +1165,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		virtual int GetLevel (void) const override { return m_pClass->GetLevel(); }
 		virtual Metric GetMass (void) const override;
 		virtual int GetMaxPower (void) const override;
-		virtual int GetMaxCounterValue (void) override { return m_pClass->GetHullDesc().GetMaxCounter(); };
+		virtual int GetMaxCounterValue (void) const override { return m_pClass->GetHullDesc().GetMaxCounter(); };
 		virtual CString GetNamePattern (DWORD dwNounPhraseFlags = 0, DWORD *retdwFlags = NULL) const override;
 		virtual const CInstalledDevice *GetNamedDevice (DeviceNames iDev) const override;
 		virtual CInstalledDevice *GetNamedDevice (DeviceNames iDev) override;
@@ -1184,6 +1185,8 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		virtual const CShipPerformanceDesc &GetShipPerformance (void) const override { return m_Perf; }
 		virtual CSovereign *GetSovereign (void) const override { return m_pSovereign; }
 		virtual int GetStealth (void) const override;
+		virtual int GetStealthAdj (void) const override { return m_pClass->GetHullDesc().GetStealthAdj(); }
+		virtual int GetStealthAdjAtMaxHeat (void) const override { return m_pClass->GetHullDesc().GetStealthAdjAtMaxHeat(); }
 		virtual Metric GetMaxSpeed (void) const override { return m_Perf.GetDriveDesc().GetMaxSpeed(); }
 		virtual Metric GetMaxWeaponRange (void) const override;
 		virtual CSpaceObject *GetTarget (DWORD dwFlags = 0) const override;
@@ -1388,7 +1391,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 
 		mutable Metric m_rItemMass = 0.0;			//	Total mass of all items (including installed)
 		mutable Metric m_rCargoMass = 0.0;			//	Mass of cargo items (not including installed)
-		int m_iStealth = 0;							//	Computed stealth
+		int m_iStealthFromArmor = 0;				//	Computed stealth from armor
 		int m_iCounterValue = 0;					//	Heat/capacitor counter value
 
 		CSpaceObject *m_pDocked = NULL;				//	If not NULL, object we are docked to.

--- a/Mammoth/Include/TSEStationType.h
+++ b/Mammoth/Include/TSEStationType.h
@@ -513,7 +513,7 @@ class CStationType : public CDesignType
 		const CRegenDesc &GetShipRegenDesc (void) { return m_ShipRegen; }
 		CSovereign *GetSovereign (void) const { return m_pSovereign; }
 		CG32bitPixel GetSpaceColor (void) const { return m_Star.GetSpaceColor(); }
-		int GetStealth (void) const { return m_iStealth; }
+		int GetStealth (void) const { return m_iStealthFromArmor; }
 		int GetTempChance (void) const { return m_iChance; }
 		bool HasAnimations (void) const { return (m_pAnimations != NULL); }
 		bool HasGravity (void) const { return m_Star.HasGravity(); }
@@ -638,7 +638,7 @@ class CStationType : public CDesignType
 
 		//	Armor & Hull
 		CStationHullDesc m_HullDesc;					//	Hull descriptor
-		int m_iStealth = 0;								//	Stealth
+		int m_iStealthFromArmor = 0;								//	Stealth
 
 		//	Devices
 		IDeviceGenerator *m_pDevices = NULL;			//	Devices for the station

--- a/Mammoth/Include/TSEUtil.h
+++ b/Mammoth/Include/TSEUtil.h
@@ -657,7 +657,8 @@ class CPerceptionCalc
 	public:
 		enum EConstants
 			{
-			RANGE_ARRAY_SIZE = 16,
+			RANGE_ARRAY_SIZE = 256,
+			RANGE_ARRAY_BASE_RANGE_INDEX = 128, //  index at which detection range is 100
 			};
 
 		CPerceptionCalc (int iPerception = -1);
@@ -680,6 +681,7 @@ class CPerceptionCalc
 		bool IsVisibleDueToAttack (CSpaceObject *pTarget) const;
 
 		static void InitRangeTable (void);
+		static Metric CalcPerceptionRange (int iStealth, int iPerception) { return 100.0 * std::pow(1.2, float(iPerception - iStealth)); };
 
 		int m_iPerception;
 		DWORD m_dwLastAttackThreshold;			//	Last attack on or after means visible

--- a/Mammoth/Include/TSEVersions.h
+++ b/Mammoth/Include/TSEVersions.h
@@ -132,7 +132,7 @@ constexpr DWORD SYSTEM_SAVE_VERSION =					194;
 //		m_iCountdown in CStandardShipAI
 //
 //	 5: 0.97
-//		m_iStealth in CShip
+//		m_iStealthFromArmor in CShip
 //
 //	 6-14: 0.98
 //		m_Blacklist in CBaseShipAI

--- a/Mammoth/Include/TSEWeaponFireDesc.h
+++ b/Mammoth/Include/TSEWeaponFireDesc.h
@@ -720,7 +720,7 @@ class CWeaponFireDesc
 		Metric GetRatedSpeed (void) const { return m_rMissileSpeed; }
 		CWeaponFireDesc *GetScaledDesc (int iLevel) const;
 		int GetSpecialDamage (SpecialDamageTypes iSpecial, DWORD dwFlags = 0) const;
-		int GetStealth (void) const { return m_iStealth; }
+		int GetStealth (void) const { return m_iStealthFromArmor; }
 		bool GetTargetable (void) const { return m_fTargetable; }
 		FireTypes GetType (void) const { return m_iFireType; }
 		const CString &GetUNID (void) const { return m_sUNID; }
@@ -819,7 +819,7 @@ class CWeaponFireDesc
 		//	Missile stuff (m_iFireType == ftMissile)
 		int m_iAccelerationFactor = 0;			//	% increase in speed per 10 ticks
 		Metric m_rMaxMissileSpeed = 0.0;		//	Max speed.
-		int m_iStealth = 0;						//	Missile stealth
+		int m_iStealthFromArmor = 0;						//	Missile stealth
 		int m_iHitPoints = 0;					//	HP before dissipating (0 = destroyed by any hit)
 		int m_iInteraction = 0;					//	Interaction opacity (0-100)
 		int m_iManeuverability = 0;				//	Tracking maneuverability (0 = none)

--- a/Mammoth/TSE/CArmorClass.cpp
+++ b/Mammoth/TSE/CArmorClass.cpp
@@ -901,13 +901,13 @@ int CArmorClass::CalcBalance (const CArmorItem &ArmorItem, CArmorItem::SBalance 
 
 	//	Stealth
 
-	if (m_iStealth >= 12)
+	if (m_iStealthFromArmor >= 12)
 		retBalance.rStealth = 4.0 * STEALTH_BALANCE_BONUS;
-	else if (m_iStealth >= 10)
+	else if (m_iStealthFromArmor >= 10)
 		retBalance.rStealth = 3.0 * STEALTH_BALANCE_BONUS;
-	else if (m_iStealth >= 8)
+	else if (m_iStealthFromArmor >= 8)
 		retBalance.rStealth = 2.0 * STEALTH_BALANCE_BONUS;
-	else if (m_iStealth >= 6)
+	else if (m_iStealthFromArmor >= 6)
 		retBalance.rStealth = 1.0 * STEALTH_BALANCE_BONUS;
 	else
 		retBalance.rStealth = 0.0;
@@ -1628,9 +1628,9 @@ ALERROR CArmorClass::CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, CIt
 
 	//	Stealth
 
-	pArmor->m_iStealth = pDesc->GetAttributeInteger(STEALTH_ATTRIB);
-	if (pArmor->m_iStealth == 0)
-		pArmor->m_iStealth = CSpaceObject::stealthNormal;
+	pArmor->m_iStealthFromArmor = pDesc->GetAttributeInteger(STEALTH_ATTRIB);
+	if (pArmor->m_iStealthFromArmor == 0)
+		pArmor->m_iStealthFromArmor = CSpaceObject::stealthNormal;
 
 	pArmor->m_iMaxHPBonus = pDesc->GetAttributeIntegerBounded(MAX_HP_BONUS_ATTRIB, 0, -1, 150);
 

--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -2096,6 +2096,8 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'selectedWeapon\n"
 			"   'shatterImmune\n"
 			"   'showMapLabel\n"
+			"   'stealthAdj\n"
+			"   'stealthAdjAtMaxHeat\n"
 			"   'target\n"
 			"   'thrust -> in GN\n"
 			"   'thrustToWeight -> acceleration, 1 = 500 m/s^2 (ships stats show this / 1000)\n"

--- a/Mammoth/TSE/CHullDesc.cpp
+++ b/Mammoth/TSE/CHullDesc.cpp
@@ -22,6 +22,8 @@
 #define MAX_REACTOR_POWER_ATTRIB				CONSTLIT("maxReactorPower")
 #define MAX_WEAPONS_ATTRIB						CONSTLIT("maxWeapons")
 #define SIZE_ATTRIB								CONSTLIT("size")
+#define STEALTH_ADJ_ATTRIB						CONSTLIT("stealthAdj")
+#define STEALTH_ADJ_AT_MAX_HEAT_ATTRIB			CONSTLIT("stealthAdjAtMaxHeat")
 #define TIME_STOP_IMMUNE_ATTRIB					CONSTLIT("timeStopImmune")
 #define VALUE_ATTRIB							CONSTLIT("value")
 #define VALUE_ADJ_ATTRIB						CONSTLIT("valueAdj")
@@ -130,6 +132,8 @@ ALERROR CHullDesc::InitFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, int iMa
 	
 	m_iCounterIncrementRate = pHull->GetAttributeInteger(COUNTER_INCREMENT_RATE_ATTRIB);
 	m_iMaxCounter = pHull->GetAttributeInteger(MAX_COUNTER_ATTRIB);
+	m_iStealthAdj = pHull->GetAttributeInteger(STEALTH_ADJ_ATTRIB);
+	m_iStealthAdjAtMaxHeat = pHull->GetAttributeInteger(STEALTH_ADJ_AT_MAX_HEAT_ATTRIB);
 
 	//	If we've got our own element (<Hull>) then parse any children
 

--- a/Mammoth/TSE/CPerceptionCalc.cpp
+++ b/Mammoth/TSE/CPerceptionCalc.cpp
@@ -12,25 +12,7 @@ const DWORD LAST_ATTACK_THRESHOLD =					45;
 
 bool CPerceptionCalc::m_bRangeTableInitialized = false;
 
-Metric CPerceptionCalc::m_rRange[RANGE_ARRAY_SIZE] = 
-	{
-	(250.0 * LIGHT_SECOND),
-	(175.0 * LIGHT_SECOND),
-	(145.0 * LIGHT_SECOND),
-	(120.0 * LIGHT_SECOND),
-	(100.0 * LIGHT_SECOND),
-	(83.0 * LIGHT_SECOND),
-	(69.0 * LIGHT_SECOND),
-	(58.0 * LIGHT_SECOND),
-	(48.0 * LIGHT_SECOND),
-	(40.0 * LIGHT_SECOND),
-	(33.0 * LIGHT_SECOND),
-	(28.0 * LIGHT_SECOND),
-	(23.0 * LIGHT_SECOND),
-	(19.0 * LIGHT_SECOND),
-	(16.0 * LIGHT_SECOND),
-	(13.0 * LIGHT_SECOND),
-	};
+Metric CPerceptionCalc::m_rRange[RANGE_ARRAY_SIZE];
 
 Metric CPerceptionCalc::m_rRange2[RANGE_ARRAY_SIZE];
 
@@ -113,7 +95,7 @@ int CPerceptionCalc::GetRangeIndex (int iStealth, int iPerception)
 //	stealth.
 
 	{
-	int iResult = (iStealth - iPerception) + 4;
+	int iResult = (iStealth - iPerception) + RANGE_ARRAY_BASE_RANGE_INDEX;
 
 	//	We are easily visible at any range
 
@@ -134,7 +116,10 @@ void CPerceptionCalc::InitRangeTable (void)
 	{
 	int i;
 	for (i = 0; i < RANGE_ARRAY_SIZE; i++)
+		{
+		m_rRange[i] = CalcPerceptionRange(RANGE_ARRAY_SIZE - RANGE_ARRAY_BASE_RANGE_INDEX, RANGE_ARRAY_SIZE - i) * LIGHT_SECOND;
 		m_rRange2[i] = m_rRange[i] * m_rRange[i];
+		}
 
 	m_bRangeTableInitialized = true;
 	}

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -95,6 +95,8 @@ const DWORD MAX_DISRUPT_TIME_BEFORE_DAMAGE =	(60 * g_TicksPerSecond);
 #define PROPERTY_SELECTED_WEAPON				CONSTLIT("selectedWeapon")
 #define PROPERTY_SHATTER_IMMUNE					CONSTLIT("shatterImmune")
 #define PROPERTY_SHOW_MAP_LABEL					CONSTLIT("showMapLabel")
+#define PROPERTY_STEALTH_ADJ					CONSTLIT("stealthAdj")
+#define PROPERTY_STEALTH_ADJ_AT_MAX_HEAT		CONSTLIT("stealthAdjAtMaxHeat")
 #define PROPERTY_TARGET							CONSTLIT("target")
 #define PROPERTY_THRUST							CONSTLIT("thrust")
 #define PROPERTY_THRUST_TO_WEIGHT				CONSTLIT("thrustToWeight")
@@ -323,7 +325,7 @@ void CShip::CalcArmorBonus (void)
 
 	//	Loop over all armor segments and compute some values.
 
-	m_iStealth = stealthMax;
+	m_iStealthFromArmor = stealthMax;
 
 	for (i = 0; i < SegmentsByType.GetCount(); i++)
 		{
@@ -368,8 +370,8 @@ void CShip::CalcArmorBonus (void)
 
 			//	Compute stealth
 
-			if (pArmor->GetClass()->GetStealth() < m_iStealth)
-				m_iStealth = pArmor->GetClass()->GetStealth();
+			if (pArmor->GetClass()->GetStealth() < m_iStealthFromArmor)
+				m_iStealthFromArmor = pArmor->GetClass()->GetStealth();
 			}
 		}
 
@@ -3272,6 +3274,12 @@ ICCItem *CShip::GetPropertyCompatible (CCodeChainCtx &Ctx, const CString &sName)
 	else if (strEquals(sName, PROPERTY_SHOW_MAP_LABEL))
 		return CC.CreateBool(m_fShowMapLabel);
 
+	else if (strEquals(sName, PROPERTY_STEALTH_ADJ))
+		return CC.CreateInteger(m_pClass->GetHullDesc().GetStealthAdj());
+
+	else if (strEquals(sName, PROPERTY_STEALTH_ADJ_AT_MAX_HEAT))
+		return CC.CreateInteger(m_pClass->GetHullDesc().GetStealthAdjAtMaxHeat());
+
 	//	Drive properties
 
 	else if (strEquals(sName, PROPERTY_DRIVE_POWER))
@@ -3394,12 +3402,26 @@ int CShip::GetStealth (void) const
 //	Returns the stealth of the ship
 
 	{
-	int iStealth = m_iStealth;
+	int iStealth = m_iStealthFromArmor;
 
 	//	+6 stealth if in nebula, which decreases detection range by about 3.
 
 	if (m_fHiddenByNebula)
 		iStealth += 6;
+
+	//  Calculate the intrinsic stealth value of the ship.
+
+	int iStealthAdj = GetStealthAdj();
+
+	//  If the ship has negative counter increment (aka counter is used for heat), interpolate between
+	//  maximum and initial intrinsic stealth values
+	if (GetCounterIsHeat())
+		{
+		float fStealthAdjDelta = (float(GetCounterValue()) / float(GetMaxCounterValue())) * (GetStealthAdjAtMaxHeat() - GetStealthAdj());
+		iStealthAdj += int(round(fStealthAdjDelta));
+		}
+
+	iStealth += iStealthAdj;
 
 	return Min((int)stealthMax, iStealth);
 	}
@@ -5646,7 +5668,7 @@ void CShip::OnReadFromStream (SLoadCtx &Ctx)
 //	CArmorSystem m_Armor
 //
 //	CAbilitySet	m_Ability
-//	DWORD		m_iStealth
+//	DWORD		m_iStealthFromArmor
 //
 //	CPowerConsumption	m_pPowerUse (if tracking fuel)
 //
@@ -5892,9 +5914,9 @@ void CShip::OnReadFromStream (SLoadCtx &Ctx)
 	//	Stealth
 
 	if (Ctx.dwVersion >= 5)
-		Ctx.pStream->Read(m_iStealth);
+		Ctx.pStream->Read(m_iStealthFromArmor);
 	else
-		m_iStealth = stealthNormal;
+		m_iStealthFromArmor = stealthNormal;
 
 	//	Fuel consumption
 
@@ -6263,7 +6285,7 @@ void CShip::OnWriteToStream (IWriteStream *pStream)
 //  CArmorSystem m_Armor
 //
 //	CAbilitySet	m_Ability
-//	DWORD		m_iStealth
+//	DWORD		m_iStealthFromArmor
 //
 //	CPowerConsumption	m_pPowerUse (if tracking fuel)
 //
@@ -6367,7 +6389,7 @@ void CShip::OnWriteToStream (IWriteStream *pStream)
 
 	//	Stealth
 
-	pStream->Write(m_iStealth);
+	pStream->Write(m_iStealthFromArmor);
 
 	//	Fuel consumption
 

--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -106,26 +106,6 @@ const Metric g_rMaxCommsRange2 =				(g_rMaxCommsRange * g_rMaxCommsRange);
 
 #define SPECIAL_VALUE_TRUE						CONSTLIT("true")
 
-static Metric g_rMaxPerceptionRange[CSpaceObject::perceptMax+1] =
-	{
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	0.0,
-	};
-
 struct SInstallItemResultsData
 	{
 	const char *pszID;

--- a/Mammoth/TSE/CStationType.cpp
+++ b/Mammoth/TSE/CStationType.cpp
@@ -1581,7 +1581,7 @@ ALERROR CStationType::OnCreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc)
 	m_fAnonymous = pDesc->GetAttributeBool(ANONYMOUS_ATTRIB);
 	m_iAlertWhenAttacked = pDesc->GetAttributeInteger(ALERT_WHEN_ATTACKED_ATTRIB);
 	m_iAlertWhenDestroyed = pDesc->GetAttributeInteger(ALERT_WHEN_DESTROYED_ATTRIB);
-	m_iStealth = pDesc->GetAttributeIntegerBounded(STEALTH_ATTRIB, CSpaceObject::stealthMin, CSpaceObject::stealthMax, CSpaceObject::stealthNormal);
+	m_iStealthFromArmor = pDesc->GetAttributeIntegerBounded(STEALTH_ATTRIB, CSpaceObject::stealthMin, CSpaceObject::stealthMax, CSpaceObject::stealthNormal);
 
 	//	Can attack?
 

--- a/Mammoth/TSE/CWeaponFireDesc.cpp
+++ b/Mammoth/TSE/CWeaponFireDesc.cpp
@@ -1759,7 +1759,7 @@ void CWeaponFireDesc::InitFromDamage (const DamageDesc &Damage)
 
 	//	Load stealth
 
-	m_iStealth = CSpaceObject::stealthNormal;
+	m_iStealthFromArmor = CSpaceObject::stealthNormal;
 
 	//	Load specific properties
 
@@ -1930,7 +1930,7 @@ ALERROR CWeaponFireDesc::InitFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, c
 
 	//	Load stealth
 
-	m_iStealth = pDesc->GetAttributeIntegerBounded(STEALTH_ATTRIB, CSpaceObject::stealthMin, CSpaceObject::stealthMax, CSpaceObject::stealthNormal);
+	m_iStealthFromArmor = pDesc->GetAttributeIntegerBounded(STEALTH_ATTRIB, CSpaceObject::stealthMin, CSpaceObject::stealthMax, CSpaceObject::stealthNormal);
 
 	//	Initialize interaction and hit points
 
@@ -2574,7 +2574,7 @@ ALERROR CWeaponFireDesc::InitScaledStats (SDesignLoadCtx &Ctx, CXMLElement *pDes
 
 	m_iAccelerationFactor = Src.m_iAccelerationFactor;
 	m_rMaxMissileSpeed = Src.m_rMaxMissileSpeed;
-	m_iStealth = Src.m_iStealth;
+	m_iStealthFromArmor = Src.m_iStealthFromArmor;
 	m_iHitPoints = Src.m_iHitPoints;
 	m_iInteraction = Src.m_iInteraction;
 	m_iManeuverability = Src.m_iManeuverability;

--- a/Mammoth/TSUI/CReactorHUDCircular.cpp
+++ b/Mammoth/TSUI/CReactorHUDCircular.cpp
@@ -189,7 +189,7 @@ void CReactorHUDCircular::PaintCounterGauge(CShip *pShip)
 
 	Metric rCounterValue = ((Metric)pShip->GetCounterValue() / (Metric)pShip->GetMaxCounterValue());
 	Metric rBoundedCounterValue = Min(1.0, ((Metric)pShip->GetCounterValue() / (Metric)pShip->GetMaxCounterValue()));
-	bool rCounterIsHeat = (pShip->GetCounterIncrementRate() < 0 ? true : false);
+	bool rCounterIsHeat = (pShip->GetCounterIsHeat());
 
 	//	Paint the background
 


### PR DESCRIPTION
2 major changes: increase perception/stealth dynamic range to +-128, and enable
intrinsic stealth bonuses/penalties on ship hulls.

Note regarding new stealth/perception detection range:
The same formula is used for perception/stealth as before, so most values
should stay the same albeit with slight differences since they are now
calculated mathematically. The one significant difference is that if
perception = stealth + 4, detection range is 210 rather than 250
(perception = stealth + 5 gives detection range of 250).

