### PR TITLE
Misc fixes for 1.9b4

### DIFF
--- a/Transcendence/TransCore/CommonwealthFleet.xml
+++ b/Transcendence/TransCore/CommonwealthFleet.xml
@@ -990,6 +990,8 @@ PLAYER DATA
 			valueBonusPerCharge="150"
 
 			description=		"This external pod is loaded with thirty-six XM900 nuclear missiles and can be installed without the aid of a station."
+
+			showChargesInUseMenu="true"
 			>
 
 		<Image imageID="&rsItemsNAMI4;" imageX="288" imageY="0" imageWidth="96" imageHeight="96"/>

--- a/Transcendence/TransCore/CommonwealthVolunteerMission02.xml
+++ b/Transcendence/TransCore/CommonwealthVolunteerMission02.xml
@@ -171,7 +171,7 @@
 				several civilian deaths. The station council has voted to 
 				authorize its destruction.
 
-				"Your mission is to destroy the station and any defender. We'll
+				"Your mission is to destroy the station and any defenders. We'll
 				pay %reward% if you succeed. Interested?"
 
 			</Text>

--- a/Transcendence/TransCore/CorporateAutonDealer.xml
+++ b/Transcendence/TransCore/CorporateAutonDealer.xml
@@ -355,7 +355,7 @@
 									(switch
 										;	Auton has hull damage and armor damage
 
-										(and hullDamage (ls armorHPLeft armorHPMax))
+										(and (gr hullDamage 0) (ls armorHPLeft armorHPMax))
 											(block ()
 												(setq repairArmor True)
 												(setq repairHull True)
@@ -464,6 +464,7 @@
 
 							(if (scrGetData gScreen 'repairHull)
 								(block (
+									(autonConfig (@ theEntry 'autonConfig))
 									)
 									(set@ autonConfig 'maxHullHP Nil)
 									(set@ autonConfig 'hullHP Nil)

--- a/Transcendence/TransCore/Psych01.xml
+++ b/Transcendence/TransCore/Psych01.xml
@@ -9,6 +9,7 @@
 			maxAppearing=		"1"
 			priority=			"100"
 			noDebrief=			"true"
+			recordNonPlayer=	"true"
 			>
 
 		<Properties>

--- a/Transcendence/TransCore/RPGDockServices.xml
+++ b/Transcendence/TransCore/RPGDockServices.xml
@@ -752,6 +752,7 @@
 								(scrShowScreen gScreen &dsRPGInstallDevice; {
 									criteria: "sUN"
 									checkMilitaryID: (@ gData 'checkMilitaryID)
+									replaceItem: (scrGetItem gScreen)
 									title: (@ gData 'title)
 									shipObj: (@ gData 'shipObj)
 									})

--- a/Transcendence/TransCore/StdWeapons.xml
+++ b/Transcendence/TransCore/StdWeapons.xml
@@ -21,6 +21,8 @@
 			valueBonusPerCharge="5"
 
 			description=		"This disposable weapon system is loaded with thirty-two KM100 missiles. The weapon can be installed and uninstalled without the aid of a station."
+
+			showChargesInUseMenu="true"
 			>
 
 		<Image imageID="&rsItemsNAMI2;" imageX="96" imageY="0" imageWidth="96" imageHeight="96"/>
@@ -198,6 +200,8 @@
 			valueBonusPerCharge="15"
 
 			description=		"The DM1500 is loaded with thirty-two KM500 tracking missiles. This weapon can be installed and uninstalled without the aid of a station."
+
+			showChargesInUseMenu="true"
 			>
 
 		<Image imageID="&rsItemsNAMI2;" imageX="192" imageY="0" imageWidth="96" imageHeight="96"/>


### PR DESCRIPTION
Fixes for auton dealer (see [Auton repair and salvage bugs](https://ministry.kronosaur.com/record.hexm?id=96574))
* Consider `hullDamage == 0` as undamaged and do not display "Hull: 0% integrity"
* Add missing `autonConfig` definition when repairing hull so custom auton configuration is not lost

Add `showChargesInUseMenu="true"` to disposable launchers so player can see remaining missiles in [U]se menu

Add missing `replaceItem` when replacing shields so player can compare old / new devices (as already done for misc devices and weapons)