### PR TITLE
Prioritize guns with smaller firing arcs when trying to align guns on target

### DIFF
--- a/Mammoth/TSE/ShipAIImpl.h
+++ b/Mammoth/TSE/ShipAIImpl.h
@@ -195,7 +195,7 @@ class CAIBehaviorCtx
 		bool CalcFlockingFormationRandom (CShip *pShip, CSpaceObject *pLeader, CVector *retvPos, CVector *retvVel, int *retiFacing);
 		bool ImplementAttackTargetManeuver (CShip *pShip, CSpaceObject *pTarget, const CVector &vTarget, Metric rTargetDist2);
 		void GetPrimaryWeaponsToFire (CShip* pShip, CSpaceObject *pTarget, Metric rTargetDist2, TArray<CInstalledDevice*> &pWeaponsToFire, TArray<Metric> &rWeaponRanges);
-		void FireWeaponIfOnTarget (CShip* pShip, CSpaceObject *pTarget, CInstalledDevice *pWeaponToFire, Metric rWeaponRange, Metric rTargetDist2, bool bDoNotShoot, int *retiFacingAngle, int *retiAngleToTarget);
+		void FireWeaponIfOnTarget (CShip* pShip, CSpaceObject *pTarget, CInstalledDevice *pWeaponToFire, Metric rWeaponRange, Metric rTargetDist2, bool bDoNotShoot, int *retiFacingAngle, int *retiAngleToTarget, bool *retbIsAligned = nullptr);
 
 		CAISettings m_AISettings;					//	Settings
 


### PR DESCRIPTION
Certain IA ships with wide arc broadside guns and forward firing guns with narrow arcs prefer to keep their broadside guns pointed towards the enemy instead of bringing their forward guns to bear. This PR attempts to deprioritize guns that are on target and that have wide firing arcs, in an attempt to remedy this.