### PR TITLE
Fix C3DConversion::CalcPolar returning incorrect position with positive Y values

### DIFF
--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -156,6 +156,9 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	Metric rXp = vPos.GetX() / g_KlicksPerPixel;
 	Metric rYp = vPos.GetY() / g_KlicksPerPixel;
 
+	bool bYIsPositive = rYp > 0.0;
+	rYp = -abs(rYp);
+
 	Metric rDen = (rYp * g_rK1) - (rD * g_rK2);
 	if (rDen == 0.0)
 		rDen = 0.1;
@@ -168,6 +171,8 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	rX = rX * rScale;
 
 	Metric rAngle = VectorToPolarRadians(CVector(rX, rY), retrRadius);
+	if (bYIsPositive)
+		rAngle = -rAngle;
 	if (retrAngle)
 		*retrAngle = rAngle;
 	}

--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -156,9 +156,6 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	Metric rXp = vPos.GetX() / g_KlicksPerPixel;
 	Metric rYp = vPos.GetY() / g_KlicksPerPixel;
 
-	bool bYIsPositive = rYp > 0.0;
-	rYp = -abs(rYp);
-
 	Metric rDen = (rYp * g_rK1) - (rD * g_rK2);
 	if (rDen == 0.0)
 		rDen = 0.1;
@@ -171,8 +168,6 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	rX = rX * rScale;
 
 	Metric rAngle = VectorToPolarRadians(CVector(rX, rY), retrRadius);
-	if (bYIsPositive)
-		rAngle = -rAngle;
 	if (retrAngle)
 		*retrAngle = rAngle;
 	}

--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -191,7 +191,7 @@ ALERROR C3DConversion::Init (CXMLElement *pDesc)
 	C3DObjectPos Pos;
 	bool b3DPos;
 
-	Pos.InitFromXML(pDesc, C3DObjectPos::FLAG_CALC_POLAR, &b3DPos);
+	Pos.InitFromXML(pDesc, 0, &b3DPos);
 	m_iAngle = Pos.GetAngle();
 	m_iRadius = Pos.GetRadius();
 	m_iZ = Pos.GetZ();

--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -156,23 +156,18 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	Metric rXp = vPos.GetX() / g_KlicksPerPixel;
 	Metric rYp = vPos.GetY() / g_KlicksPerPixel;
 
-	bool bYIsPositive = rYp > 0.0;
-	rYp = -abs(rYp);
-
-	Metric rDen = (rYp * g_rK1) - (rD * g_rK2);
+	Metric rDen = (rXp * g_rK1) - (rD * g_rK2);
 	if (rDen == 0.0)
 		rDen = 0.1;
 
-	Metric rY = (-(rZ * g_rK1 * rD) - (rYp * rZ * g_rK2) - (2.0 * rYp)) / rDen;
-	Metric rYg = rY * g_rK2 - rZ * g_rK1;
-	Metric rX = (rYp == 0.0 ? rXp / rScale : rXp * rYg / rYp);
+	Metric rX = (-(rZ * g_rK1 * rD) - (rXp * rZ * g_rK2) - (2.0 * rXp)) / rDen;
+	Metric rXg = rX * g_rK2 - rZ * g_rK1;
+	Metric rY = (rXp == 0.0 ? rYp / rScale : rYp * rXg / rXp);
 
 	rY = rY * rScale;
 	rX = rX * rScale;
 
 	Metric rAngle = VectorToPolarRadians(CVector(rX, rY), retrRadius);
-	if (bYIsPositive)
-		rAngle = -rAngle;
 	if (retrAngle)
 		*retrAngle = rAngle;
 	}

--- a/Mammoth/TSE/C3DConversion.cpp
+++ b/Mammoth/TSE/C3DConversion.cpp
@@ -156,18 +156,23 @@ void C3DConversion::CalcPolar (int iScale, const CVector &vPos, int iZ, Metric *
 	Metric rXp = vPos.GetX() / g_KlicksPerPixel;
 	Metric rYp = vPos.GetY() / g_KlicksPerPixel;
 
-	Metric rDen = (rXp * g_rK1) - (rD * g_rK2);
+	bool bYIsPositive = rYp > 0.0;
+	rYp = -abs(rYp);
+
+	Metric rDen = (rYp * g_rK1) - (rD * g_rK2);
 	if (rDen == 0.0)
 		rDen = 0.1;
 
-	Metric rX = (-(rZ * g_rK1 * rD) - (rXp * rZ * g_rK2) - (2.0 * rXp)) / rDen;
-	Metric rXg = rX * g_rK2 - rZ * g_rK1;
-	Metric rY = (rXp == 0.0 ? rYp / rScale : rYp * rXg / rXp);
+	Metric rY = (-(rZ * g_rK1 * rD) - (rYp * rZ * g_rK2) - (2.0 * rYp)) / rDen;
+	Metric rYg = rY * g_rK2 - rZ * g_rK1;
+	Metric rX = (rYp == 0.0 ? rXp / rScale : rXp * rYg / rYp);
 
 	rY = rY * rScale;
 	rX = rX * rScale;
 
 	Metric rAngle = VectorToPolarRadians(CVector(rX, rY), retrRadius);
+	if (bYIsPositive)
+		rAngle = -rAngle;
 	if (retrAngle)
 		*retrAngle = rAngle;
 	}

--- a/Mammoth/TSE/CDeviceTable.cpp
+++ b/Mammoth/TSE/CDeviceTable.cpp
@@ -261,7 +261,7 @@ ALERROR IDeviceGenerator::InitDeviceDescFromXML (SDesignLoadCtx &Ctx, CXMLElemen
 	retDesc->sID = pDesc->GetAttribute(ID_ATTRIB);
 
 	C3DObjectPos Pos;
-	if (Pos.InitFromXML(pDesc, C3DObjectPos::FLAG_CALC_POLAR, &retDesc->b3DPosition))
+	if (Pos.InitFromXML(pDesc, 0, &retDesc->b3DPosition))
 		{
 		retDesc->iPosAngle = Pos.GetAngle();
 		retDesc->iPosRadius = Pos.GetRadius();
@@ -644,7 +644,7 @@ ALERROR CSingleDevice::LoadFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc)
 	//	Load device position attributes
 
 	C3DObjectPos Pos;
-	if (Pos.InitFromXML(pDesc, C3DObjectPos::FLAG_CALC_POLAR, &m_b3DPosition))
+	if (Pos.InitFromXML(pDesc, 0, &m_b3DPosition))
 		{
 		m_iPosAngle = Pos.GetAngle();
 		m_iPosRadius = Pos.GetRadius();


### PR DESCRIPTION
`C3DConversion::CalcPolar` seems to return different radii when `vPos` Y value is positive, than when it is negative. This fix does a simple fix by forcing the calculation to return the result for when Y is negative, but inverting the angle if Y is positive - which makes it return the correct radius and angle.