### PR TITLE
Heat update

### DIFF
--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -1290,7 +1290,7 @@ class CSpaceObject
 		virtual CurrencyValue GetBalancedTreasure (void) const { return 0; }
 		virtual Metric GetCargoSpaceLeft (void) const { return 1000000.0; }
 		virtual int GetCombatPower (void) { return 0; }
-		virtual int GetCounterIncrementRate (void) const { return 0; }
+		virtual int GetCounterIncrementRate (SUpdateCtx& Ctx) const { return 0; }
 		virtual bool GetCounterIsHeat (void) const { return false; }
 		virtual int GetCounterValue (void) const { return 0; }
 		virtual int GetCyberDefenseLevel (void) const { return GetLevel(); }

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -325,7 +325,8 @@ class CDeviceClass
 		virtual const CRepairerClass *AsRepairerClass (void) const { return NULL; }
 		virtual CShieldClass *AsShieldClass (void) { return NULL; }
 		virtual CWeaponClass *AsWeaponClass (void) { return NULL; }
-		virtual bool CalcFireSolution (const CInstalledDevice &Device, CSpaceObject &Target, int *retiAimAngle = NULL, Metric *retrDist = NULL) const { return false; }
+		virtual int CalcCounterDelta (const SUpdateCtx& Ctx, const CInstalledDevice* pDevice, const CSpaceObject* pSource) { return 0; }
+		virtual bool CalcFireSolution (const CInstalledDevice &Device, const CSpaceObject &Target, int *retiAimAngle = NULL, Metric *retrDist = NULL) const { return false; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) { return 0; }
 		virtual bool CanHitFriends (void) const { return true; }
 		virtual void Deplete (CInstalledDevice *pDevice, CSpaceObject *pSource) { }
@@ -587,6 +588,7 @@ class CInstalledDevice
 		DWORD GetData (void) const { return m_dwData; }
 		int GetDeviceSlot (void) const { return m_iDeviceSlot; }
 		TSharedPtr<CItemEnhancementStack> GetEnhancementStack (void) const { return m_pEnhancements; }
+		int GetExtraCounterPerTick (void) const { return m_iExtraCounterPerTick; }
 		int GetExtraPowerUse (void) const { return m_iExtraPowerUse; }
 		ItemFates GetFate (void) const;
 		int GetFireAngle (void) const { return m_iFireAngle; }
@@ -675,6 +677,7 @@ class CInstalledDevice
 		bool Activate (CDeviceClass::SActivateCtx &ActivateCtx)
 			{ return m_pClass->Activate(*this, ActivateCtx); }
 		int CalcPowerUsed (SUpdateCtx &Ctx, CSpaceObject *pSource);
+		int CalcCounterDelta (const SUpdateCtx& Ctx, const CSpaceObject *pSource) const;
 		bool CanBeDamaged (void) { return m_pClass->CanBeDamaged(); }
 		bool CanBeDisabled (CItemCtx &Ctx) { return m_pClass->CanBeDisabled(Ctx); }
 		bool CanBeDisrupted (void) { return m_pClass->CanBeDisrupted(); }
@@ -774,6 +777,7 @@ class CInstalledDevice
 		int m_iActivateDelay:16 = 0;				//	Cached activation delay
 		int m_iExtraPowerUse:16 = 0;				//	Additional power use per tick
 		int m_iSlotPosIndex:16 = -1;				//	Slot placement
+		int m_iExtraCounterPerTick:32 = 0;
 
 		DWORD m_fOmniDirectional:1 = false;			//	Installed on turret
 		DWORD m_fOverdrive:1 = false;				//	Device has overdrive installed

--- a/Mammoth/Include/TSEShipSystems.h
+++ b/Mammoth/Include/TSEShipSystems.h
@@ -180,6 +180,7 @@ class CDeviceSystem
 		void AccumulateHUDTimers (const CSpaceObject &Source, TArray<SHUDTimerDesc> &retTimers) const;
 		void AccumulatePerformance (SShipPerformanceCtx &Ctx) const;
 		void AccumulatePowerUsed (SUpdateCtx &Ctx, CSpaceObject *pObj, int &iPowerUsed, int &iPowerGenerated);
+		int AccumulateCounterIncrement (const SUpdateCtx& Ctx, const CSpaceObject *pObj) const;
 		int CalcSlotsInUse (int *retiWeaponSlots, int *retiNonWeapon, int *retiLauncherSlots) const;
 		void CleanUp (void);
 		CInstalledDevice *FindDevice (const CItem &Item);

--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1170,7 +1170,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		virtual DWORD GetClassUNID (void) override { return m_pClass->GetUNID(); }
 		virtual int GetCombatPower (void) override;
 		virtual int GetCounterValue (void) const override { return m_iCounterValue; }
-		virtual int GetCounterIncrementRate (void) const override { return m_pClass->GetHullDesc().GetCounterIncrementRate(); }
+		virtual int GetCounterIncrementRate (SUpdateCtx& Ctx) const override;
 		virtual bool GetCounterIsHeat (void) const override { return m_pClass->GetHullDesc().GetCounterIncrementRate() < 0; }
 		virtual const CCurrencyBlock *GetCurrencyBlock (void) const override;
 		virtual CCurrencyBlock *GetCurrencyBlock (bool bCreate = false) override;

--- a/Mammoth/Include/TSEVersions.h
+++ b/Mammoth/Include/TSEVersions.h
@@ -7,7 +7,7 @@
 
 constexpr DWORD API_VERSION =							53;
 constexpr DWORD UNIVERSE_SAVE_VERSION =					40;
-constexpr DWORD SYSTEM_SAVE_VERSION =					211;
+constexpr DWORD SYSTEM_SAVE_VERSION =					212;
 
 //	Uncomment out the following define when building a stable release
 

--- a/Mammoth/TSE/CDeviceSystem.cpp
+++ b/Mammoth/TSE/CDeviceSystem.cpp
@@ -125,6 +125,21 @@ void CDeviceSystem::AccumulatePowerUsed (SUpdateCtx &Ctx, CSpaceObject *pObj, in
 		}
 	}
 
+int CDeviceSystem::AccumulateCounterIncrement(const SUpdateCtx &Ctx, const CSpaceObject* pObj) const
+
+//	AccumulateCounterIncrement
+//
+//	Get the net delta of the heat/energy counter for all devices.
+
+{
+	int iCounterDelta = 0;
+	for (int i = 0; i < m_Devices.GetCount(); i++)
+		{
+		iCounterDelta += m_Devices[i]->CalcCounterDelta(Ctx, pObj);
+		}
+	return iCounterDelta;
+}
+
 int CDeviceSystem::CalcSlotsInUse (int *retiWeaponSlots, int *retiNonWeapon, int *retiLauncherSlots) const
 
 //	CalcSlotsInUse

--- a/Mammoth/TSE/CInstalledDevice.cpp
+++ b/Mammoth/TSE/CInstalledDevice.cpp
@@ -13,6 +13,7 @@
 #define PROPERTY_CYCLE_FIRE 					CONSTLIT("cycleFire")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
+#define PROPERTY_EXTRA_COUNTER_PER_TICK			CONSTLIT("extraCounterPerTick")
 #define PROPERTY_EXTRA_POWER_USE				CONSTLIT("extraPowerUse")
 #define PROPERTY_FIRE_ARC						CONSTLIT("fireArc")
 #define PROPERTY_LINKED_FIRE_OPTIONS			CONSTLIT("linkedFireOptions")
@@ -38,6 +39,28 @@ bool CInstalledDevice::AccumulateSlotEnhancements (CSpaceObject *pSource, TArray
 		bEnhanced = m_SlotEnhancements.Accumulate(GetLevel(), *GetItem(), *pEnhancements, &EnhancementIDs);
 
 	return bEnhanced;
+	}
+
+int CInstalledDevice::CalcCounterDelta(const SUpdateCtx& Ctx, const CSpaceObject* pSource) const
+
+//	CalcPowerUsed
+//
+//	Calculates how much heat this device generated this tick. Positive numbers indicate
+//	heat generation, negative numbers are heat dissipation.
+	{
+
+	if (IsEmpty())
+		return 0;
+
+	//	Let the device compute heat generation.
+
+	int iCounterDelta = m_pClass->CalcCounterDelta(Ctx, this, pSource);
+
+	//	Add extra counter per tick.
+
+	iCounterDelta += m_iExtraCounterPerTick;
+
+	return iCounterDelta;
 	}
 
 int CInstalledDevice::CalcPowerUsed (SUpdateCtx &Ctx, CSpaceObject *pSource)
@@ -361,6 +384,7 @@ void CInstalledDevice::Install (CSpaceObject &Source, CItemListManipulator &Item
 	m_pOverlay = NULL;
 	m_dwData = 0;
 	m_iExtraPowerUse = 0;
+	m_iExtraCounterPerTick = 0;
 	m_iTemperature = 0;
 	m_fWaiting = false;
 	m_fEnabled = true;
@@ -713,6 +737,17 @@ void CInstalledDevice::ReadFromStream (CSpaceObject &Source, SLoadCtx &Ctx)
 		{
 		m_iShotSeparationScale = 32767;
 		m_iMaxFireRange = 0;
+		}
+
+
+	if (Ctx.dwVersion >= 212)
+		{
+		Ctx.pStream->Read(dwLoad);
+		m_iExtraCounterPerTick = (int)dwLoad;
+		}
+	else
+		{
+		m_iExtraCounterPerTick = 0;
 		}
 
 	Ctx.pStream->Read(dwLoad);
@@ -1069,6 +1104,11 @@ ESetPropertyResult CInstalledDevice::SetProperty (CItemCtx &Ctx, const CString &
 			}
 		}
 
+	else if (strEquals(sName, PROPERTY_EXTRA_COUNTER_PER_TICK))
+		{
+		m_iExtraCounterPerTick = pValue->GetIntegerValue();
+		}
+
 	else if (strEquals(sName, PROPERTY_EXTRA_POWER_USE))
 		{
 		m_iExtraPowerUse = pValue->GetIntegerValue();
@@ -1378,6 +1418,9 @@ void CInstalledDevice::WriteToStream (IWriteStream *pStream)
 	pStream->Write(dwSave);
 
 	dwSave = MAKELONG(m_iShotSeparationScale, m_iMaxFireRange);
+	pStream->Write(dwSave);
+
+	dwSave = DWORD(m_iExtraCounterPerTick) & 0xffffffff;
 	pStream->Write(dwSave);
 
 	dwSave = 0;

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -2653,6 +2653,29 @@ int CShip::GetCombatPower (void)
 	return m_pController->GetCombatPower();
 	}
 
+int CShip::GetCounterIncrementRate(SUpdateCtx& Ctx) const
+
+//	GetCounterIncrementRate
+//
+//	Get the amount to increment the ship's heat/energy counter this tick.
+//	We obtain this by getting both the hull's innate increment rate, and the increment rates of all devices.
+
+	{
+	//	Hull's innate increment rate
+
+	int iHullCounterIncrementRate = m_pClass->GetHullDesc().GetCounterIncrementRate();
+
+	//	Devices can affect the counter increment rate
+
+	iHullCounterIncrementRate += m_Devices.AccumulateCounterIncrement(Ctx, this);
+
+	//	Armor can affect the counter increment rate
+
+	//m_Armor.AccumulatePowerUsed(Ctx, this, iPowerUsed, iPowerGenerated);
+
+	return iHullCounterIncrementRate;
+	}
+
 const CCurrencyBlock *CShip::GetCurrencyBlock (void) const
 
 //	GetCurrencyBlock

--- a/Mammoth/TSE/Devices.cpp
+++ b/Mammoth/TSE/Devices.cpp
@@ -45,6 +45,7 @@
 #define PROPERTY_DEVICE_SLOTS					CONSTLIT("deviceSlots")
 #define PROPERTY_ENABLED						CONSTLIT("enabled")
 #define PROPERTY_EXTERNAL						CONSTLIT("external")
+#define PROPERTY_EXTRA_COUNTER_PER_TICK			CONSTLIT("extraCounterPerTick")
 #define PROPERTY_EXTRA_POWER_USE				CONSTLIT("extraPowerUse")
 #define PROPERTY_FIRE_ARC						CONSTLIT("fireArc")
 #define PROPERTY_LINKED_FIRE_OPTIONS			CONSTLIT("linkedFireOptions")

--- a/Mammoth/TSE/ShipProperties.cpp
+++ b/Mammoth/TSE/ShipProperties.cpp
@@ -331,7 +331,7 @@ ICCItem *CShip::GetPropertyCompatible (CCodeChainCtx &Ctx, const CString &sName)
 		return CC.CreateInteger(GetCounterValue());
 
 	else if (strEquals(sName, PROPERTY_COUNTER_INCREMENT_RATE))
-		return CC.CreateInteger(GetCounterIncrementRate());
+		return CC.CreateInteger(GetClass().GetHullDesc().GetCounterIncrementRate());
 
 	else if (strEquals(sName, PROPERTY_CHALLENGE_RATING))
 		return CC.CreateInteger(CChallengeRatingCalculator::CalcChallengeRating(*this));

--- a/Mammoth/TSE/ShipUpdate.cpp
+++ b/Mammoth/TSE/ShipUpdate.cpp
@@ -246,19 +246,10 @@ void CShip::OnUpdate (SUpdateCtx &Ctx, Metric rSecondsPerTick)
 
 	//	Update
 
-	int iCounterIncRate = m_pClass->GetHullDesc().GetCounterIncrementRate();
-	if (iCounterIncRate > 0)
-		{
-		//	If counter increment rate is greater than zero, then we allow the counter value to be unbounded below
-		//	but bounded above
-		m_iCounterValue = Min(m_iCounterValue + iCounterIncRate, m_pClass->GetHullDesc().GetMaxCounter());
-		}
-	else
-		{
-		//	Else we allow the counter value to be unbounded above
-		//	but bounded below
-		m_iCounterValue = Max(0, m_iCounterValue + iCounterIncRate);
-		}
+	int iCounterIncRate = GetCounterIncrementRate(Ctx);
+	//	We allow the counter value to be unbounded above
+	//	but bounded below
+	m_iCounterValue = Max(0, m_iCounterValue + iCounterIncRate);
 
 	DEBUG_CATCH
 	}


### PR DESCRIPTION
- [ ] Rename all occurrences of ship "counter" to "heat" and remove all occurrences of "counter" being referred to as "energy" including weapons that "consume" energy, or HUD display showing it as "energy"
- [ ] Add field that allows all devices to increment or decrement heat each tick, both while enabled and disabled (for now) - maybe some other functions for things like weapons and shields like e.g. shields generating heat while taking damage
- [ ] Add field that allows all armours to increment or decrement heat each tick
- [ ] Add field that allows devices to increase or decrease the heat limit for a ship
- [ ] Add `<OnOverheat>` event to ships; this triggers every update if the ship's heat exceeds 100% - if it doesn't exist, then damage ship armour if above 100%, with a chance to damage ship devices and armour if above 150% and chance/damage increasing with higher heat
- [ ] Allow players to fire weapons if the ship is overheating, but play a warning noise every time a weapon is fired with the heat at 90% or over - only do this if the last warning is more than 30 ticks ago to avoid spam