### PR TITLE
Intro Screen: detach space background from top bar

### DIFF
--- a/Mammoth/TSE/CSystemSpacePainter.cpp
+++ b/Mammoth/TSE/CSystemSpacePainter.cpp
@@ -345,7 +345,7 @@ void CSystemSpacePainter::PaintSpaceBackground (CG32bitImage &Dest, int xCenter,
 
 	PainterCtx.pBackground = m_pBackground;
 	PainterCtx.xBackground = ClockMod(xCenter / 4, cxImage);
-	PainterCtx.yBackground = ClockMod(-yCenter / 4, cyImage);
+	PainterCtx.yBackground = ClockMod(Ctx.rcView.top - yCenter / 4, cyImage);
 
 	//	Compute the chunks
 


### PR DESCRIPTION
When hiding the bars on the Intro Screen, the top edge of the space background is attached to the bottom edge of the top bar.