### PR TITLE
Add hull integrity display for player ship on HUD; use actual ship armour spans for HUD armour display

### DIFF
--- a/Mammoth/Include/TSESpaceObjectsImpl.h
+++ b/Mammoth/Include/TSESpaceObjectsImpl.h
@@ -1029,6 +1029,7 @@ class CShip : public TSpaceObjectImpl<OBJID_CSHIP>
 		virtual bool IsMultiHull (void) const override { return m_pClass->GetInteriorDesc().IsMultiHull(); }
 
 		void GetAttachedSectionInfo (TArray<SAttachedSectionInfo> &Result) const;
+		const CShipInterior& GetInteriorDesc (void) const { return m_Interior; }
 		bool HasAttachedSections (void) const { return m_fHasShipCompartments; }
 		bool IsShipSection (void) const { return m_fShipCompartment; }
 		bool RepairInterior (int iRepairHP) { return m_Interior.RepairHitPoints(this, m_pClass->GetInteriorDesc(), iRepairHP); }

--- a/Mammoth/TSUI/CArmorHUDRingSegments.cpp
+++ b/Mammoth/TSUI/CArmorHUDRingSegments.cpp
@@ -11,6 +11,7 @@
 #define SCALE_ATTRIB							CONSTLIT("scale")
 #define SEGMENT_ATTRIB							CONSTLIT("segment")
 #define SHIELDS_COLOR_ATTRIB					CONSTLIT("shieldsColor")
+#define NO_HP_LABEL_ATTRIB						CONSTLIT("noHPLabel")
 
 #define SCALE_HP								CONSTLIT("hp")
 #define SCALE_PERCENT							CONSTLIT("percent")
@@ -501,6 +502,7 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 	CGDraw::Circle(m_Buffer, m_xCenter, m_yCenter, m_iArmorInnerRadius, CG32bitPixel(CG32bitPixel::Desaturate(m_rgbArmor), 80), CGDraw::blendCompositeNormal);
 
 	//	Paint each of the armor segments, one at a time.
+	const CShipArmorDesc &ArmorDesc = pShip->GetClass()->GetArmorDesc();
 
 	for (CArmorItem ArmorItem : pShip->GetArmorSystem())
 		{
@@ -510,14 +512,17 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 		Seg.sHP = ArmorItem.GetHPDisplay(m_HPDisplay, &Seg.iIntegrity);
 		int iWidth = (Seg.iIntegrity * m_iArmorRingWidth) / 100;
 
+		int iSegStartAngle = ArmorDesc.GetSegment(ArmorItem.GetSegmentIndex()).GetStartAngle() + 90;
+		int iGetEndAngle = iSegStartAngle + ArmorDesc.GetSegment(ArmorItem.GetSegmentIndex()).GetSpan();
+
 		//	Draw the full armor size
 
 		CGDraw::Arc(m_Buffer, 
 				m_xCenter, 
 				m_yCenter, 
 				m_iArmorInnerRadius, 
-				Seg.iStartAngle, 
-				Seg.iEndAngle, 
+				iSegStartAngle,
+				iGetEndAngle,
 				m_iArmorRingWidth, 
 				rgbArmorBack, 
 				CGDraw::blendCompositeNormal, 
@@ -530,8 +535,8 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 				m_xCenter, 
 				m_yCenter, 
 				m_iArmorInnerRadius, 
-				Seg.iStartAngle, 
-				Seg.iEndAngle, 
+				iSegStartAngle,
+				iGetEndAngle,
 				iWidth, 
 				m_rgbArmor, 
 				CGDraw::blendCompositeNormal, 

--- a/Mammoth/TSUI/CArmorHUDRingSegments.cpp
+++ b/Mammoth/TSUI/CArmorHUDRingSegments.cpp
@@ -7,6 +7,7 @@
 
 #define ARMOR_COLOR_ATTRIB						CONSTLIT("armorColor")
 #define HP_ANGLE_ATTRIB							CONSTLIT("hpAngle")
+#define HULL_COLOR_ATTRIB						CONSTLIT("hullColor")
 #define LABEL_ANGLE_ATTRIB						CONSTLIT("labelAngle")
 #define SCALE_ATTRIB							CONSTLIT("scale")
 #define SEGMENT_ATTRIB							CONSTLIT("segment")
@@ -355,6 +356,9 @@ bool CArmorHUDRingSegments::OnCreate (SHUDCreateCtx &CreateCtx, CString *retsErr
 	m_rgbShields = ::LoadRGBColor(CreateCtx.Desc.GetAttribute(SHIELDS_COLOR_ATTRIB), CG32bitPixel(103, 204, 0));
 	m_rgbShieldsText = CG32bitPixel::Fade(m_rgbShields, CG32bitPixel(255, 255, 255), 80);
 	m_rgbShieldsTextBack = CG32bitPixel::Darken(m_rgbShields, 128);
+	m_rgbHull = ::LoadRGBColor(CreateCtx.Desc.GetAttribute(HULL_COLOR_ATTRIB), CG32bitPixel(128, 128, 128));
+	m_rgbHullText = CG32bitPixel::Fade(m_rgbHull, CG32bitPixel(255, 255, 255), 80);
+	m_rgbHullTextBack = CG32bitPixel::Darken(m_rgbHull, 128);
 
 	CString sScale = CreateCtx.Desc.GetAttribute(SCALE_ATTRIB);
 	if (sScale.IsBlank() || strEquals(sScale, SCALE_PERCENT))
@@ -376,6 +380,8 @@ bool CArmorHUDRingSegments::OnCreate (SHUDCreateCtx &CreateCtx, CString *retsErr
 	m_iArmorInnerRadius = m_iArmorRingRadius - m_iArmorRingWidth;
 	m_iArmorNameRadius = m_iArmorRingRadius + RING_SPACING + m_iShieldRingWidth + RING_SPACING;
 
+	m_iHullCircleRadius = m_iArmorInnerRadius - RING_SPACING;
+
 	//	Calculate metrics
 
 	int iTotalRadius = m_iArmorRingRadius + RING_SPACING + m_iShieldRingWidth;
@@ -388,6 +394,7 @@ bool CArmorHUDRingSegments::OnCreate (SHUDCreateCtx &CreateCtx, CString *retsErr
 	//	Measure out metrics for armor/shield integrity text
 
 	m_cxMaxValue = MediumFont.MeasureText(CONSTLIT("100%"), &m_cyMaxValue);
+	m_bNoHPLabel = CreateCtx.Desc.GetAttributeBool(NO_HP_LABEL_ATTRIB);
 
 	//	Initialize armor segment metrics
 
@@ -499,7 +506,17 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 	//	Paint the ship
 
 	pShip->GetClass()->PaintScaled(m_Buffer, m_xCenter, m_yCenter, 2 * m_iArmorInnerRadius, 2 * m_iArmorInnerRadius, 90, 0);
-	CGDraw::Circle(m_Buffer, m_xCenter, m_yCenter, m_iArmorInnerRadius, CG32bitPixel(CG32bitPixel::Desaturate(m_rgbArmor), 80), CGDraw::blendCompositeNormal);
+
+	int iHullCircleRadius = m_iArmorInnerRadius;
+	int iHullHP = 0;
+	int iMaxHullHP = 0;
+	pShip->GetInteriorDesc().GetHitPoints(*pShip, pShip->GetClass()->GetInteriorDesc(), &iHullHP, &iMaxHullHP);
+	if (iMaxHullHP > 0)
+		{
+		iHullCircleRadius = int(iHullCircleRadius * float(iHullHP) / float(iMaxHullHP));
+		}
+
+	CGDraw::Circle(m_Buffer, m_xCenter, m_yCenter, iHullCircleRadius, CG32bitPixel(CG32bitPixel::Desaturate(m_rgbHull), iMaxHullHP > 0 ? 200 : 80), CGDraw::blendCompositeNormal);
 
 	//	Paint each of the armor segments, one at a time.
 	const CShipArmorDesc &ArmorDesc = pShip->GetClass()->GetArmorDesc();
@@ -555,13 +572,13 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 
 		//	Draw armor integrity box
 
-		if (!bSelected)
+		if (!bSelected && !m_bNoHPLabel)
 			DrawIntegrityBox(m_Buffer, Seg, m_rgbArmorTextBack);
 		}
 
 	//	Paint the selected HP box
 
-	if (Ctx.iSegmentSelected != -1)
+	if (Ctx.iSegmentSelected != -1 && !m_bNoHPLabel)
 		{
 		SSegment &Seg = m_Segments[Ctx.iSegmentSelected];
 
@@ -570,11 +587,14 @@ void CArmorHUDRingSegments::Realize (SHUDPaintCtx &Ctx)
 
 	//	Paint the HP values
 
-	for (int i = 0; i < m_Segments.GetCount(); i++)
+	if (!m_bNoHPLabel)
 		{
-		SSegment &Seg = m_Segments[i];
+		for (int i = 0; i < m_Segments.GetCount(); i++)
+			{
+			SSegment& Seg = m_Segments[i];
 
-		DrawIntegrityBoxText(m_Buffer, Seg, m_rgbArmorText);
+			DrawIntegrityBoxText(m_Buffer, Seg, m_rgbArmorText);
+			}
 		}
 
 	//	Paint shield level

--- a/Mammoth/TSUI/HUDImpl.h
+++ b/Mammoth/TSUI/HUDImpl.h
@@ -382,14 +382,20 @@ class CArmorHUDRingSegments : public IHUDPainter
 		CG32bitPixel m_rgbShields = CG32bitPixel(0xff, 0xff, 0xff);			//	Color of shields
 		CG32bitPixel m_rgbShieldsText = CG32bitPixel(0x00, 0x00, 0x00);		//	Shield text color
 		CG32bitPixel m_rgbShieldsTextBack = CG32bitPixel(0xff, 0xff, 0xff);	//	Shield text background color
+		CG32bitPixel m_rgbHull = CG32bitPixel(0xff, 0xff, 0xff);			//	Color of hull
+		CG32bitPixel m_rgbHullText = CG32bitPixel(0x00, 0x00, 0x00);		//	Hull text color
+		CG32bitPixel m_rgbHullTextBack = CG32bitPixel(0xff, 0xff, 0xff);	//	Hull text background color
 
 		int m_iArmorRingRadius = 100;
 		int m_iArmorRingWidth = 10;
 		int m_iArmorInnerRadius = 90;
 		int m_iArmorNameRadius = 90;
 		int m_iShieldRingWidth = 10;
+		int m_iHullCircleRadius = 80;
 		CLanguage::SHPDisplayOptions m_HPDisplay;
 		TArray<SSegment> m_Segments;
+
+		bool m_bNoHPLabel = false;
 
 		//	Metrics
 

--- a/Mammoth/TSUI/HUDImpl.h
+++ b/Mammoth/TSUI/HUDImpl.h
@@ -369,6 +369,7 @@ class CArmorHUDRingSegments : public IHUDPainter
 		void DrawArmorName (CG32bitImage &Dest, int iAngle, int iRadius, CShip *pShip, CArmorItem ArmorItem, CG32bitPixel rgbBack, CG32bitPixel rgbColor);
 		void DrawIntegrityBox (CG32bitImage &Dest, const SSegment &Seg, CG32bitPixel rgbBack) const;
 		void DrawIntegrityBoxText (CG32bitImage &Dest, const SSegment &Seg, CG32bitPixel rgbColor) const;
+		void DrawHullIntegrityText (CG32bitImage &Dest, const int iHP, const int iMaxHP, const CLanguage::SHPDisplayOptions& Options, CG32bitPixel rgbColor) const;
 		void DrawItemBox (CG32bitImage &Dest, int iAngle, int iRadius, const CString &sName, const TArray<SDisplayAttribute> &Attribs, CG32bitPixel rgbBack, CG32bitPixel rgbColor);
 		void DrawShieldsIntegrity (CG32bitImage &Dest, int iAngle, int iRadius, const CString &sHP, CG32bitPixel rgbBack, CG32bitPixel rgbColor) const;
 		void DrawShieldsName (CG32bitImage &Dest, int iAngle, int iRadius, CShip *pShip, CDeviceItem ShieldItem, CG32bitPixel rgbBack, CG32bitPixel rgbColor);


### PR DESCRIPTION
New fields added for the HUD are `hullColor` which denotes the color of the hull bubble indicator (in the same format as `armorColor` and `shieldColor`), and `noArmorHPLabel` which removes HP percentage labels on armor segments (useful for capships with many armor segments).

Video to show how it looks: https://streamable.com/0xn030