### PR TITLE
Feature/103766 universal ammo shields

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -482,6 +482,8 @@ class CShieldClass : public CDeviceClass
 
 		CItemCriteria GetShieldAmmoCriteria(void) const { return CItemCriteria(m_sShieldAmmoCriteria); }
 		bool UsesShieldAmmo(void) const { return m_sShieldAmmoCriteria.GetLength() > 0; }
+		int GetShieldAmmoAIPollingRate(void) const { return m_iShieldAmmoAIPollInterval; }
+		int GetShieldAmmoAIRegenAt(void) const { return m_iShieldAmmoAIRegenAt; }
 
 		//	CDeviceClass virtuals
 
@@ -582,7 +584,9 @@ class CShieldClass : public CDeviceClass
 		CEffectCreatorRef m_pHitEffect;				//	Effect when shield is hit, appearing at hit location
 		CEffectCreatorRef m_pFlashEffect;			//	Effect when shield is hit, appearing on ship
 
-		CString m_sShieldAmmoCriteria = CString("");			//	Attribute string for shield ammo type
+		CString m_sShieldAmmoCriteria;			//	Attribute string for shield ammo type
+		int m_iShieldAmmoAIPollInterval;
+		int m_iShieldAmmoAIRegenAt;
 	};
 
 class CSolarDeviceClass : public CDeviceClass

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -480,6 +480,9 @@ class CShieldClass : public CDeviceClass
 			return true;
 			}
 
+		CItemCriteria GetShieldAmmoCriteria(void) const { return CItemCriteria(m_sShieldAmmoCriteria); }
+		bool UsesShieldAmmo(void) const { return m_sShieldAmmoCriteria.GetLength() > 0; }
+
 		//	CDeviceClass virtuals
 
 		virtual bool AbsorbsWeaponFire (CInstalledDevice *pDevice, CSpaceObject *pSource, CInstalledDevice *pWeapon) override;
@@ -578,6 +581,8 @@ class CShieldClass : public CDeviceClass
 
 		CEffectCreatorRef m_pHitEffect;				//	Effect when shield is hit, appearing at hit location
 		CEffectCreatorRef m_pFlashEffect;			//	Effect when shield is hit, appearing on ship
+
+		CString m_sShieldAmmoCriteria = CString("");			//	Attribute string for shield ammo type
 	};
 
 class CSolarDeviceClass : public CDeviceClass

--- a/Mammoth/TSE/CAIBehaviorCtx.cpp
+++ b/Mammoth/TSE/CAIBehaviorCtx.cpp
@@ -458,10 +458,12 @@ void CAIBehaviorCtx::CalcInvariants (CShip *pShip)
 				}
 
 			case itemcatShields:
+				{
 				m_pShields = &Device;
-				if (Device.GetClass()->GetUNID() == g_SuperconductingShieldsUNID)
+				if (Device.GetClass()->AsShieldClass()->UsesShieldAmmo())
 					m_fSuperconductingShields = true;
 				break;
+				}
 			}
 		}
 

--- a/Mammoth/TSE/CBaseShipAI.cpp
+++ b/Mammoth/TSE/CBaseShipAI.cpp
@@ -2409,21 +2409,34 @@ void CBaseShipAI::UseItemsBehavior (void)
 			&& m_pShip->GetShieldLevel() < 40)
 		{
 		//	Look for superconducting coils
+		int iDevices = m_pShip->GetDeviceCount();
+		CItemType* pType = NULL;
+		for (int i = 0; i < iDevices; i++)
+			{
+			if (m_pShip->GetDevice(i)->GetCategory() == itemcatShields)
+				{
+				int iUNID = m_pShip->GetDevice(i)->GetUNID();
+				pType = m_pShip->GetUniverse().FindItemType(iUNID);
+				break;
+				}
+			}
 
-		CItemType *pType = m_pShip->GetUniverse().FindItemType(g_SuperconductingCoilUNID);
 		if (pType)
 			{
-			CItem Coils(pType, 1);
-			CItemListManipulator ItemList(m_pShip->GetItemList());
-			
-			if (ItemList.SetCursorAtItem(Coils))
+			CItemList shipItems = m_pShip->GetItemList();
+			for (int i = 0; i < shipItems.GetCount(); i++)
 				{
-				m_pShip->UseItem(Coils);
-				m_pShip->OnComponentChanged(comCargo);
+				CItemCriteria shieldAmmoCriteria = pType->GetDeviceClass()->AsShieldClass()->GetShieldAmmoCriteria();
+				if (shipItems.GetItem(i).MatchesCriteria(shieldAmmoCriteria))
+					{
+					CItem shieldAmmo = shipItems.GetItem(i);
+					m_pShip->UseItem(shieldAmmo);
+					m_pShip->OnComponentChanged(comCargo);
+					break;
+					}
 				}
 			}
 		}
-
 	DEBUG_CATCH
 	}
 

--- a/Mammoth/TSE/CBaseShipAI.cpp
+++ b/Mammoth/TSE/CBaseShipAI.cpp
@@ -2404,11 +2404,9 @@ void CBaseShipAI::UseItemsBehavior (void)
 	if (m_pShip->IsDestinyTime(ITEM_ON_AI_UPDATE_CYCLE, ITEM_ON_AI_UPDATE_OFFSET))
 		m_pShip->FireItemOnAIUpdate();
 
-	if (m_AICtx.HasSuperconductingShields()
-			&& m_pShip->IsDestinyTime(61)
-			&& m_pShip->GetShieldLevel() < 40)
+	if (m_AICtx.HasSuperconductingShields())
 		{
-		//	Look for superconducting coils
+		//	Look for shield
 		int iDevices = m_pShip->GetDeviceCount();
 		CItemType* pType = NULL;
 		for (int i = 0; i < iDevices; i++)
@@ -2421,18 +2419,25 @@ void CBaseShipAI::UseItemsBehavior (void)
 				}
 			}
 
+		//	Look for appropriate shield ammo
 		if (pType)
 			{
-			CItemList shipItems = m_pShip->GetItemList();
-			for (int i = 0; i < shipItems.GetCount(); i++)
+			int iPollInterval = pType->GetDeviceClass()->AsShieldClass()->GetShieldAmmoAIPollingRate();
+			int iShieldLevel = pType->GetDeviceClass()->AsShieldClass()->GetShieldAmmoAIRegenAt();
+			if ( m_pShip->IsDestinyTime(iPollInterval)
+				&& m_pShip->GetShieldLevel() <= iShieldLevel)
 				{
-				CItemCriteria shieldAmmoCriteria = pType->GetDeviceClass()->AsShieldClass()->GetShieldAmmoCriteria();
-				if (shipItems.GetItem(i).MatchesCriteria(shieldAmmoCriteria))
+				CItemList shipItems = m_pShip->GetItemList();
+				for (int i = 0; i < shipItems.GetCount(); i++)
 					{
-					CItem shieldAmmo = shipItems.GetItem(i);
-					m_pShip->UseItem(shieldAmmo);
-					m_pShip->OnComponentChanged(comCargo);
-					break;
+					CItemCriteria shieldAmmoCriteria = pType->GetDeviceClass()->AsShieldClass()->GetShieldAmmoCriteria();
+					if (shipItems.GetItem(i).MatchesCriteria(shieldAmmoCriteria))
+						{
+						CItem shieldAmmo = shipItems.GetItem(i);
+						m_pShip->UseItem(shieldAmmo);
+						m_pShip->OnComponentChanged(comCargo);
+						break;
+						}
 					}
 				}
 			}

--- a/Mammoth/TSE/CShieldClass.cpp
+++ b/Mammoth/TSE/CShieldClass.cpp
@@ -28,7 +28,9 @@
 #define REGEN_ADJ_PER_CHARGE_ATTRIB				CONSTLIT("regenHPBonusPerCharge")
 #define REGEN_TIME_ATTRIB						CONSTLIT("regenTime")
 #define REGEN_TYPE_ATTRIB						CONSTLIT("regenType")
-#define SHIELD_REGEN_AMMO_ATTRIB				CONSTLIT("shieldAmmoCriteria")
+#define SHIELD_AMMO_CRITERIA_ATTRIB				CONSTLIT("shieldAmmoCriteria")
+#define SHIELD_AMMO_AI_POLLING_ATTRIB			CONSTLIT("shieldAmmoAIPollRate")
+#define SHIELD_AMMO_AI_RECHARGE_AT_ATTRIB		CONSTLIT("shieldAmmoAIRechargeAtPercent")
 #define TIME_BETWEEN_FLASH_EFFECTS_ATTRIB		CONSTLIT("timeBetweenFlashEffects")
 #define WEAPON_SUPPRESS_ATTRIB					CONSTLIT("weaponSuppress")
 
@@ -687,7 +689,9 @@ ALERROR CShieldClass::CreateFromXML (SDesignLoadCtx &Ctx, SInitCtx &InitCtx, CXM
 
 	//  Store shield ammo filter
 
-	pShield->m_sShieldAmmoCriteria = pDesc->GetAttribute(SHIELD_REGEN_AMMO_ATTRIB);
+	pShield->m_sShieldAmmoCriteria = pDesc->GetAttribute(SHIELD_AMMO_CRITERIA_ATTRIB);
+	pShield->m_iShieldAmmoAIRegenAt = pDesc->GetAttributeIntegerBounded(SHIELD_AMMO_AI_RECHARGE_AT_ATTRIB, 0, 99, 0);
+	pShield->m_iShieldAmmoAIPollInterval = pDesc->GetAttributeIntegerBounded(SHIELD_AMMO_AI_POLLING_ATTRIB, 1, INT_MAX, 61);
 
 	//	Load regen value
 

--- a/Mammoth/TSE/CShieldClass.cpp
+++ b/Mammoth/TSE/CShieldClass.cpp
@@ -28,6 +28,7 @@
 #define REGEN_ADJ_PER_CHARGE_ATTRIB				CONSTLIT("regenHPBonusPerCharge")
 #define REGEN_TIME_ATTRIB						CONSTLIT("regenTime")
 #define REGEN_TYPE_ATTRIB						CONSTLIT("regenType")
+#define SHIELD_REGEN_AMMO_ATTRIB				CONSTLIT("shieldAmmoCriteria")
 #define TIME_BETWEEN_FLASH_EFFECTS_ATTRIB		CONSTLIT("timeBetweenFlashEffects")
 #define WEAPON_SUPPRESS_ATTRIB					CONSTLIT("weaponSuppress")
 
@@ -683,6 +684,10 @@ ALERROR CShieldClass::CreateFromXML (SDesignLoadCtx &Ctx, SInitCtx &InitCtx, CXM
 	//	on the item type.
 
 	InitCtx.iMaxCharges = pDesc->GetAttributeIntegerBounded(MAX_CHARGES_ATTRIB, 0, -1, -1);
+
+	//  Store shield ammo filter
+
+	pShield->m_sShieldAmmoCriteria = pDesc->GetAttribute(SHIELD_REGEN_AMMO_ATTRIB);
 
 	//	Load regen value
 
@@ -1879,12 +1884,7 @@ bool CShieldClass::RequiresItems (void) const
 //	Shield requires some other item to function
 
 	{
-#ifdef LATER
-	//	Need to explicitly list superconducting coils as a required
-	//	item for these shields to function
-#else
-	return m_Regen.IsEmpty();
-#endif
+	return (m_Regen.IsEmpty() && UsesShieldAmmo());
 	}
 
 void CShieldClass::Reset (CInstalledDevice *pDevice, CSpaceObject *pSource)

--- a/Transcendence/TransCore/StdShields.xml
+++ b/Transcendence/TransCore/StdShields.xml
@@ -368,6 +368,7 @@
 				regen=			"0"
 				depletionDelay=	"0"
 				powerUse=		"50"
+				shieldAmmoCriteria=	"u +superconductingShieldCoil"
 				/>
 
 	</ItemType>
@@ -381,7 +382,7 @@
 			mass=				"100"
 			frequency=			"uncommon"
 			numberAppearing=	"1d6+1"
-			attributes=			"commonwealth, consumable, kartal"
+			attributes=			"commonwealth, consumable, kartal, superconductingShieldCoil"
 
 			description=		"This is a special type of coil used to repair superconducting shield generators."
 			>

--- a/Transcendence/TransCore/StdShields.xml
+++ b/Transcendence/TransCore/StdShields.xml
@@ -369,6 +369,8 @@
 				depletionDelay=	"0"
 				powerUse=		"50"
 				shieldAmmoCriteria=	"u +superconductingShieldCoil"
+				shieldAmmoAIPollRate=	"61"
+				shieldAmmoAIRechargeAtPercent=	"40"
 				/>
 
 	</ItemType>


### PR DESCRIPTION
This PR allows AI ships to make use of ammo using shields like the superconducting shield. The original implementation was locked to the base-game UNIDs of the superconducting shield and coil. This new version uses item criteria and customizable AI behavior..