### PR TITLE
fix: 103768: allow balance computations up to an xml-specified maximum

### DIFF
--- a/Mammoth/TSE/CArmorClass.cpp
+++ b/Mammoth/TSE/CArmorClass.cpp
@@ -63,6 +63,7 @@
 #define FIELD_SHIELD_INTERFERENCE				CONSTLIT("shieldInterference")
 
 #define MASS_CLASS_STANDARD_ID					CONSTLIT("medium")
+#define MASS_CLASS_MAX_ID						CONSTLIT("maximum")
 
 #define PROPERTY_ARMOR_CLASS					CONSTLIT("armorClass")
 #define PROPERTY_BALANCE_ADJ					CONSTLIT("balanceAdj")
@@ -1100,10 +1101,11 @@ Metric CArmorClass::CalcBalanceMass (const CArmorItem &ArmorItem, const SScalabl
 	Metric rStdMass = GetUniverse().GetDesignCollection().GetArmorMassDefinitions().GetMassClassMass(MASS_CLASS_STANDARD_ID) / 1000.0;
 	Metric rAdj = (rStdMass > 0.0 ? MASS_BALANCE_STD_MASS / rStdMass : 1.0);
 
-	//	Because this is an x^2 curve, we need a limit on mass or else we will start
-	//	to curve up (more mass = bonus, which we don't want).
+	//	Need to account for everything up to the maximum defined mass class.
+	//  Anything beyond that is considered bespoke.
 
-	rMass = Min(rAdj * rMass, MASS_BALANCE_LIMIT);
+	Metric rMaxMass = GetUniverse().GetDesignCollection().GetArmorMassDefinitions().GetMassClassMass(MASS_CLASS_MAX_ID);
+	rMass = Min(rAdj * rMass, rMaxMass > 0.0 ? rMaxMass : MASS_BALANCE_LIMIT);
 
 	//	Compute the standard mass that results in 0 balance.
 

--- a/Transcendence/TransCore/StdArmor.xml
+++ b/Transcendence/TransCore/StdArmor.xml
@@ -4,6 +4,14 @@
 
 	<Type unid="&unidArmorMass;">
 		<ArmorMassDesc>
+			<!--
+				The tags "medium" and "maximum" are engine-defined and dictate how automatic balance
+				calculations take place.
+				Items above the "maximum" mass limit are considered npc-bespoke and will not return
+				valid balance numbers.
+				If "medium" is not specified, a standard armor mass of 3500kg is assumed.
+				If "maximum" is not specified, a maximum armor mass of 16000kg is assumed.
+			-->
 			<ArmorMass id="ultraLight"	label="ultra-light"		mass="1000"/>
 			<ArmorMass id="light"		label="light"			mass="2500"/>
 			<ArmorMass id="medium"		label="medium"			mass="3500"/>
@@ -11,6 +19,7 @@
 			<ArmorMass id="superHeavy"	label="super-heavy"		mass="9000"/>
 			<ArmorMass id="massive"		label="massive"			mass="12000"/>
 			<ArmorMass id="dreadnought"	label="dreadnought"		mass="100000"/>
+			<ArmorMass id="maximum"		label="maximum"			mass="1000000"/>
 		</ArmorMassDesc>
 	</Type>
 


### PR DESCRIPTION
The balance algorithm now looks for a mass class named "maximum". This is defined in the xml as 1000000kg. Anything above it will not return valid balance values.
Not specifying it results in using the legacy maximum of 16000kg.

Intended to address, which came up while working on an expanded universe project.
https://ministry.kronosaur.com/record.hexm?id=103768