### PR TITLE
fix: 103609: autodefense device improvements

### DIFF
--- a/Mammoth/Include/TSE.h
+++ b/Mammoth/Include/TSE.h
@@ -661,6 +661,7 @@ class CSpaceObject
 		virtual bool FindDeviceSlotDesc (const CItem &Item, SDeviceDesc *retDesc) { return false; }
 		bool FireCanInstallItem (const CItem &Item, const CDeviceSystem::SSlotDesc &Slot, CString *retsResult);
 		bool FireCanRemoveItem (const CItem &Item, int iSlot, CString *retsResult);
+		int GetNextAutoDefenseDeviceIndex (int iDev);
 		CInstalledDevice *GetDevice (int iDev) { return &GetDeviceSystem().GetDevice(iDev); }
 		int GetDeviceCount (void) const { return GetDeviceSystem().GetCount(); }
 		CDeviceItem GetDeviceItem (int iDev) const { return GetDeviceSystem().GetDeviceItem(iDev); }
@@ -674,6 +675,7 @@ class CSpaceObject
 		virtual void OnDeviceStatus (CInstalledDevice *pDev, CDeviceClass::DeviceNotificationTypes iEvent) { }
 		bool SetCursorAtDevice (CItemListManipulator &ItemList, int iDevSlot);
 		bool SetCursorAtDevice (CItemListManipulator &ItemList, CInstalledDevice *pDevice);
+		void UpdateAutoDefenseTargetingOnDestroy (const SDestroyCtx& Ctx);
 
 		//	Docking
 

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -36,9 +36,11 @@ class CAutoDefenseClass : public CDeviceClass
 	{
 	public:
 		static ALERROR CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, CItemType *pType, CDeviceClass **retpDevice);
+		void UpdateTargetOnDestroy(CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx);
 
 		//	CDeviceClass virtuals
 
+		virtual CAutoDefenseClass *AsAutoDefenseClass(void) override { return this; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) override;
 		virtual ICCItem *FindItemProperty (CItemCtx &Ctx, const CString &sProperty) override;
 		virtual int GetActivateDelay (CItemCtx &ItemCtx) const override;
@@ -73,6 +75,8 @@ class CAutoDefenseClass : public CDeviceClass
 		bool IsDirectional (CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc);
 		bool IsOmniDirectional (CInstalledDevice *pDevice);
 		CSpaceObject *FindTarget (CInstalledDevice *pDevice, CSpaceObject *pSource);
+		SDeviceUpdateCtx GetEmptyDeviceUpdateCtx(void);
+		void UpdateTarget(CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx);
 
 		TargetingSystemTypes m_iTargeting = trgNone;
 		CSpaceObjectCriteria m_TargetCriteria;
@@ -87,6 +91,7 @@ class CAutoDefenseClass : public CDeviceClass
 		int m_iRechargeTicks = 0;
 
 		CDeviceClassRef m_pWeapon;
+		CSpaceObject *m_pTarget;
 	};
 
 class CCargoSpaceClass : public CDeviceClass

--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -36,11 +36,11 @@ class CAutoDefenseClass : public CDeviceClass
 	{
 	public:
 		static ALERROR CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, CItemType *pType, CDeviceClass **retpDevice);
-		void UpdateTargetOnDestroy(CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx);
+		void UpdateTargetOnDestroy (CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx);
 
 		//	CDeviceClass virtuals
 
-		virtual CAutoDefenseClass *AsAutoDefenseClass(void) override { return this; }
+		virtual CAutoDefenseClass *AsAutoDefenseClass (void) override { return this; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) override;
 		virtual ICCItem *FindItemProperty (CItemCtx &Ctx, const CString &sProperty) override;
 		virtual int GetActivateDelay (CItemCtx &ItemCtx) const override;
@@ -75,8 +75,8 @@ class CAutoDefenseClass : public CDeviceClass
 		bool IsDirectional (CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc);
 		bool IsOmniDirectional (CInstalledDevice *pDevice);
 		CSpaceObject *FindTarget (CInstalledDevice *pDevice, CSpaceObject *pSource);
-		SDeviceUpdateCtx GetEmptyDeviceUpdateCtx(void);
-		void UpdateTarget(CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx);
+		SDeviceUpdateCtx GetEmptyDeviceUpdateCtx (void);
+		void UpdateTarget (CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx);
 
 		TargetingSystemTypes m_iTargeting = trgNone;
 		CSpaceObjectCriteria m_TargetCriteria;

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -333,7 +333,7 @@ class CDeviceClass
 		virtual const CRepairerClass *AsRepairerClass (void) const { return NULL; }
 		virtual CShieldClass *AsShieldClass (void) { return NULL; }
 		virtual CWeaponClass *AsWeaponClass (void) { return NULL; }
-		virtual CAutoDefenseClass *AsAutoDefenseClass(void) { return NULL; }
+		virtual CAutoDefenseClass *AsAutoDefenseClass (void) { return NULL; }
 		virtual bool CalcFireSolution (const CInstalledDevice &Device, CSpaceObject &Target, int *retiAimAngle = NULL, Metric *retrDist = NULL) const { return false; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) { return 0; }
 		virtual bool CanHitFriends (void) const { return true; }

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -10,6 +10,7 @@
 class CCargoDesc;
 class CTargetList;
 class CWeaponTargetDefinition;
+class CAutoDefenseClass;
 struct SShipPerformanceCtx;
 struct SUpdateCtx;
 
@@ -332,6 +333,7 @@ class CDeviceClass
 		virtual const CRepairerClass *AsRepairerClass (void) const { return NULL; }
 		virtual CShieldClass *AsShieldClass (void) { return NULL; }
 		virtual CWeaponClass *AsWeaponClass (void) { return NULL; }
+		virtual CAutoDefenseClass *AsAutoDefenseClass(void) { return NULL; }
 		virtual bool CalcFireSolution (const CInstalledDevice &Device, CSpaceObject &Target, int *retiAimAngle = NULL, Metric *retrDist = NULL) const { return false; }
 		virtual int CalcPowerUsed (SUpdateCtx &Ctx, CInstalledDevice *pDevice, CSpaceObject *pSource) { return 0; }
 		virtual bool CanHitFriends (void) const { return true; }
@@ -716,7 +718,7 @@ class CInstalledDevice
 		CWeaponTargetDefinition *GetWeaponTargetDefinition (void) const { return (m_pWeaponTargetDefinition.get()); }
 		bool HasLastShots (void) const { return (m_LastShotIDs.GetCount() > 0); }
 		int IncCharges (CSpaceObject *pSource, int iChange);
-		bool IsAutomatedWeapon (void) const { return m_pClass->IsAutomatedWeapon() || (IsSecondaryWeapon() && m_pWeaponTargetDefinition != nullptr); }
+		bool IsAutomatedWeapon (void) const { return m_pClass ? m_pClass->IsAutomatedWeapon() || (IsSecondaryWeapon() && m_pWeaponTargetDefinition != nullptr) : false; }
 		bool IsFirstVariantSelected(CSpaceObject *pSource) { return (m_pClass ? m_pClass->IsFirstVariantSelected(pSource, this) : true); }
 		bool IsFuelCompatible (CItemCtx &Ctx, const CItem &FuelItem) { return m_pClass->IsFuelCompatible(Ctx, FuelItem); }
 		bool IsLastVariantSelected(CSpaceObject *pSource) { return (m_pClass ? m_pClass->IsLastVariantSelected(pSource, this) : true); }

--- a/Mammoth/TSE/CAutoDefenseClass.cpp
+++ b/Mammoth/TSE/CAutoDefenseClass.cpp
@@ -201,14 +201,14 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 		}
 	}
 
-CDeviceClass::SDeviceUpdateCtx CAutoDefenseClass::GetEmptyDeviceUpdateCtx(void)
+CDeviceClass::SDeviceUpdateCtx CAutoDefenseClass::GetEmptyDeviceUpdateCtx (void)
 	{
 		SUpdateCtx uCtx;
 		SDeviceUpdateCtx DeviceUpdateCtx(uCtx, 0);
 		return DeviceUpdateCtx;
 	}
 
-void CAutoDefenseClass::UpdateTarget(CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx)
+void CAutoDefenseClass::UpdateTarget (CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx)
 	{
 
 	CDeviceClass* pWeapon = GetWeapon();
@@ -520,7 +520,7 @@ CString CAutoDefenseClass::OnGetReference (CItemCtx &Ctx, const CItem &Ammo, DWO
 		return NULL_STR;
 	}
 
-bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc)
+bool CAutoDefenseClass::IsDirectional (CInstalledDevice *pDevice, int *retiMinFireArc, int *retiMaxFireArc)
 
 //	IsDirectional
 //
@@ -587,7 +587,7 @@ bool CAutoDefenseClass::IsDirectional(CInstalledDevice *pDevice, int *retiMinFir
 		}
 	}
 
-bool CAutoDefenseClass::IsOmniDirectional(CInstalledDevice *pDevice)
+bool CAutoDefenseClass::IsOmniDirectional (CInstalledDevice *pDevice)
 
 //	IsOmniDirectional
 //
@@ -719,7 +719,7 @@ ALERROR CAutoDefenseClass::CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDes
 	return NOERROR;
 	}
 
-void CAutoDefenseClass::UpdateTargetOnDestroy(CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx)
+void CAutoDefenseClass::UpdateTargetOnDestroy (CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx)
 	{
 	if (Ctx.Obj == m_pTarget)
 		{

--- a/Mammoth/TSE/CAutoDefenseClass.cpp
+++ b/Mammoth/TSE/CAutoDefenseClass.cpp
@@ -83,7 +83,13 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 
 		case trgMissiles:
 			{
-			Metric rBestDist2 = m_rInterceptRange * m_rInterceptRange;
+			Metric rOwnerScale = max(pSource->GetImage().GetImageWidth(), pSource->GetImage().GetImageWidth()) * KLICKS_PER_PIXEL;
+			Metric rOwnerRadius = rOwnerScale / 2;
+			Metric rInterceptRange = m_rInterceptRange;
+			if (rOwnerScale >= rInterceptRange) //if radius of owner is at least half of normal intercept range
+				rInterceptRange = rInterceptRange + rOwnerRadius;
+
+			Metric rBestDist2 = rInterceptRange * rInterceptRange;
 
 			for (int i = 0; i < pSystem->GetObjectCount(); i++)
 				{
@@ -97,6 +103,12 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 						|| pObj->IsIntangible()
 						|| pObj->GetDamageSource().IsAutomatedWeapon()
 						|| !pSource->IsAngryAt(pObj->GetDamageSource())
+						|| (pObj->GetVel().GetX() > 0
+							? pObj->GetPos().GetX() + pObj->GetVel().GetX() > pSource->GetPos().GetX() + rOwnerRadius
+							: pObj->GetPos().GetX() + pObj->GetVel().GetX() < pSource->GetPos().GetX() - rOwnerRadius)
+						|| (pObj->GetVel().GetY() > 0
+							? pObj->GetPos().GetY() + pObj->GetVel().GetY() > pSource->GetPos().GetY() + rOwnerRadius
+							: pObj->GetPos().GetY() + pObj->GetVel().GetY() < pSource->GetPos().GetY() - rOwnerRadius)
 						|| (!isOmniDirectional
 								&& !AngleInArc(VectorToPolar((pObj->GetPos() - vSourcePos)), iMinFireArc, iMaxFireArc)))
 					continue;
@@ -137,12 +149,17 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 		case trgCriteria:
 			{
 			//	Compute the range
+			Metric rOwnerScale = max(pSource->GetImage().GetImageWidth(), pSource->GetImage().GetImageWidth()) * KLICKS_PER_PIXEL;
+			Metric rOwnerRadius = rOwnerScale / 2;
+			Metric rInterceptRange = m_rInterceptRange;
+			if (rOwnerScale >= rInterceptRange) //if radius of owner is at least half of normal intercept range
+				rInterceptRange = rInterceptRange + rOwnerRadius;
 
 			Metric rBestDist2;
 			if (m_TargetCriteria.MatchesMaxRadius() < g_InfiniteDistance)
 				rBestDist2 = (m_TargetCriteria.MatchesMaxRadius() * m_TargetCriteria.MatchesMaxRadius());
 			else
-				rBestDist2 = m_rInterceptRange * m_rInterceptRange;
+				rBestDist2 = rInterceptRange * rInterceptRange;
 
 			//	Now look for the nearest object
 
@@ -158,6 +175,14 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 						&& !pObj->IsIntangible()
 						&& pObj != pSource
 						&& !pObj->GetDamageSource().IsAutomatedWeapon()
+						&& (pObj->GetCategory() != CSpaceObject::catMissile ? true :
+							!((pObj->GetVel().GetX() > 0
+								? pObj->GetPos().GetX() + pObj->GetVel().GetX() > pSource->GetPos().GetX() + rOwnerRadius
+								: pObj->GetPos().GetX() + pObj->GetVel().GetX() < pSource->GetPos().GetX() - rOwnerRadius)
+							|| (pObj->GetVel().GetY() > 0
+								? pObj->GetPos().GetY() + pObj->GetVel().GetY() > pSource->GetPos().GetY() + rOwnerRadius
+								: pObj->GetPos().GetY() + pObj->GetVel().GetY() < pSource->GetPos().GetY() - rOwnerRadius))
+							)
 						&& (m_bTargetReactions || (!pObj->GetDamageSource().IsEjecta() && !pObj->GetDamageSource().IsExplosion()))
 						&& (isOmniDirectional
 								|| AngleInArc(VectorToPolar((pObj->GetPos() - vSourcePos)), iMinFireArc, iMaxFireArc)))
@@ -174,6 +199,78 @@ CSpaceObject *CAutoDefenseClass::FindTarget (CInstalledDevice *pDevice, CSpaceOb
 			ASSERT(false);
 			return NULL;
 		}
+	}
+
+CDeviceClass::SDeviceUpdateCtx CAutoDefenseClass::GetEmptyDeviceUpdateCtx(void)
+	{
+		SUpdateCtx uCtx;
+		SDeviceUpdateCtx DeviceUpdateCtx(uCtx, 0);
+		return DeviceUpdateCtx;
+	}
+
+void CAutoDefenseClass::UpdateTarget(CInstalledDevice* pDevice, CSpaceObject* pSource, SDeviceUpdateCtx& Ctx)
+	{
+
+	CDeviceClass* pWeapon = GetWeapon();
+	if (pWeapon == NULL || pDevice == NULL || pSource == NULL)
+		return;
+
+	//	Skip if we're not ready or disabled
+	//
+	//	NOTE: If pDevice is damaged or disrupted we handle this as a potential 
+	//	misfire inside of pWeapon->Activate.
+
+	if (!pDevice->IsReady() || !pDevice->IsEnabled())
+		return;
+
+	//	If the ship is disarmed or paralyzed, then we do not fire.
+
+	if (pSource->GetCondition(ECondition::paralyzed)
+		|| pSource->GetCondition(ECondition::disarmed))
+		return;
+
+	//	If we're docked with a station, then we do not fire.
+
+	if (m_bCheckLineOfFire && pSource->GetDockedObj())
+		return;
+
+	//	Look for a target; if none, then skip.
+
+	m_pTarget = FindTarget(pDevice, pSource);
+	if (m_pTarget == NULL)
+		return;
+
+	//	Shoot at target
+
+	int iFireAngle;
+	if (!pWeapon->CalcFireSolution(*pDevice, *m_pTarget, &iFireAngle))
+		return;
+
+	//	If friendlies are in the way, don't shoot
+
+	if (m_bCheckLineOfFire
+		&& !pSource->IsLineOfFireClear(pDevice, m_pTarget, iFireAngle, pSource->GetDistance(m_pTarget)))
+		return;
+
+	//	Since we're using this as a target, set the destroy notify flag
+	//	(Normally beams don't notify, so we need to override this).
+
+	m_pTarget->SetDestructionNotify();
+
+	//	Fire
+
+	SActivateCtx ActivateCtx(Ctx, m_pTarget, iFireAngle);
+
+	pWeapon->Activate(*pDevice, ActivateCtx);
+
+	Ctx.bConsumedItems = ActivateCtx.bConsumedItems;
+
+	pDevice->SetTimeUntilReady(m_iRechargeTicks);
+
+	//	Identify
+
+	if (pSource->IsPlayer())
+		pDevice->GetItem()->SetKnown();
 	}
 
 int CAutoDefenseClass::GetActivateDelay (CItemCtx &ItemCtx) const
@@ -526,62 +623,7 @@ void CAutoDefenseClass::Update (CInstalledDevice *pDevice, CSpaceObject *pSource
 
 	pWeapon->Update(pDevice, pSource, Ctx);
 
-	//	Skip if we're not ready or disabled
-	//
-	//	NOTE: If pDevice is damaged or disrupted we handle this as a potential 
-	//	misfire inside of pWeapon->Activate.
-
-	if (!pDevice->IsReady() || !pDevice->IsEnabled())
-		return;
-
-	//	If the ship is disarmed or paralyzed, then we do not fire.
-
-	if (pSource->GetCondition(ECondition::paralyzed) 
-			|| pSource->GetCondition(ECondition::disarmed))
-		return;
-
-	//	If we're docked with a station, then we do not fire.
-
-	if (m_bCheckLineOfFire && pSource->GetDockedObj())
-		return;
-
-	//	Look for a target; if none, then skip.
-
-	CSpaceObject *pTarget = FindTarget(pDevice, pSource);
-	if (pTarget == NULL)
-		return;
-
-	//	Shoot at target
-
-	int iFireAngle;
-	if (!pWeapon->CalcFireSolution(*pDevice, *pTarget, &iFireAngle))
-		return;
-
-	//	If friendlies are in the way, don't shoot
-
-	if (m_bCheckLineOfFire
-			&& !pSource->IsLineOfFireClear(pDevice, pTarget, iFireAngle, pSource->GetDistance(pTarget)))
-		return;
-
-	//	Since we're using this as a target, set the destroy notify flag
-	//	(Normally beams don't notify, so we need to override this).
-
-	pTarget->SetDestructionNotify();
-
-	//	Fire
-
-	SActivateCtx ActivateCtx(Ctx, pTarget, iFireAngle);
-
-	pWeapon->Activate(*pDevice, ActivateCtx);
-
-	Ctx.bConsumedItems = ActivateCtx.bConsumedItems;
-
-	pDevice->SetTimeUntilReady(m_iRechargeTicks);
-
-	//	Identify
-
-	if (pSource->IsPlayer())
-		pDevice->GetItem()->SetKnown();
+	UpdateTarget(pDevice, pSource, Ctx);
 
 	DEBUG_CATCH
 	}
@@ -675,6 +717,15 @@ ALERROR CAutoDefenseClass::CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDes
 	*retpDevice = pDevice;
 
 	return NOERROR;
+	}
+
+void CAutoDefenseClass::UpdateTargetOnDestroy(CInstalledDevice* pDevice, CSpaceObject* pSource, const SDestroyCtx& Ctx)
+	{
+	if (Ctx.Obj == m_pTarget)
+		{
+		SDeviceUpdateCtx dCtx = GetEmptyDeviceUpdateCtx();
+		UpdateTarget(pDevice, pSource, dCtx);
+		}
 	}
 
 ALERROR CAutoDefenseClass::OnDesignLoadComplete (SDesignLoadCtx &Ctx)

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -3885,6 +3885,10 @@ void CShip::ObjectDestroyedHook (const SDestroyCtx &Ctx)
 
 	m_pController->OnObjDestroyed(Ctx);
 
+	//  Allow autoDefense devices to update target if needed
+
+	UpdateAutoDefenseTargetingOnDestroy(Ctx);
+
 	//	If what we're docked with got destroyed, clear it
 
 	if (GetDockedObj() == Ctx.Obj)

--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -2103,7 +2103,7 @@ bool CSpaceObject::FireCanRemoveItem (const CItem &Item, int iSlot, CString *ret
 		return true;
 	}
 
-int CSpaceObject::GetNextAutoDefenseDeviceIndex(int iDev)
+int CSpaceObject::GetNextAutoDefenseDeviceIndex (int iDev)
 	{
 	if(iDev < 0)
 		return iDev;
@@ -7472,7 +7472,7 @@ bool CSpaceObject::SetCursorAtDevice (CItemListManipulator &ItemList, CInstalled
 	return SetCursorAtDevice(ItemList, pDevice->GetDeviceSlot());
 	}
 
-void CSpaceObject::UpdateAutoDefenseTargetingOnDestroy(const SDestroyCtx& Ctx)
+void CSpaceObject::UpdateAutoDefenseTargetingOnDestroy (const SDestroyCtx& Ctx)
 	{
 	int i = GetNextAutoDefenseDeviceIndex(0);
 	while (i >= 0)

--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -2103,6 +2103,18 @@ bool CSpaceObject::FireCanRemoveItem (const CItem &Item, int iSlot, CString *ret
 		return true;
 	}
 
+int CSpaceObject::GetNextAutoDefenseDeviceIndex(int iDev)
+	{
+	if(iDev < 0)
+		return iDev;
+	for (int i = iDev; i < GetDeviceCount(); i++)
+		{
+		if (GetDevice(i)->IsAutomatedWeapon())
+			return i;
+		}
+	return -1;
+	}
+
 void CSpaceObject::FireCustomEvent (const CString &sEvent, ECodeChainEvents iEvent, ICCItem *pData, ICCItem **retpResult)
 
 //	FireCustomEvent
@@ -7458,6 +7470,17 @@ bool CSpaceObject::SetCursorAtDevice (CItemListManipulator &ItemList, CInstalled
 
 	{
 	return SetCursorAtDevice(ItemList, pDevice->GetDeviceSlot());
+	}
+
+void CSpaceObject::UpdateAutoDefenseTargetingOnDestroy(const SDestroyCtx& Ctx)
+	{
+	int i = GetNextAutoDefenseDeviceIndex(0);
+	while (i >= 0)
+		{
+		GetDevice(i)->GetClass()->AsAutoDefenseClass()->UpdateTargetOnDestroy(GetDevice(i), this, Ctx);
+		i++;
+		i = GetNextAutoDefenseDeviceIndex(i);
+		}
 	}
 
 void CSpaceObject::SetCursorAtRandomItem (CItemListManipulator &ItemList, const CItemCriteria &Crit)


### PR DESCRIPTION
ticket: https://ministry.kronosaur.com/record.hexm?id=103609

autodefense devices automatically acquire new targets when their current target is destroyed, autodefense devices now wont pick targets that are flying away from them but may target them briefly as they pass by, autodefense devices get a small buff to targeting range when mounted on very large ships (ex, a CSC) unless using criteria-based distance (ex, "mEA NN:20")