### PR TITLE
fix: 104000: only set the "unable to find adventure: (adv unid)" erro…

### DIFF
--- a/Mammoth/TSE/CUniverse.cpp
+++ b/Mammoth/TSE/CUniverse.cpp
@@ -1269,7 +1269,7 @@ ALERROR CUniverse::Init (SInitDesc &Ctx, CString *retsError)
 
 				else
 					{
-					if (!retsError)
+					if (retsError->IsBlank())
 						{
 						*retsError = strPatternSubst(CONSTLIT("Unable to find adventure: %08x."), Ctx.dwAdventure);
 						}

--- a/Mammoth/TSE/CUniverse.cpp
+++ b/Mammoth/TSE/CUniverse.cpp
@@ -1269,7 +1269,10 @@ ALERROR CUniverse::Init (SInitDesc &Ctx, CString *retsError)
 
 				else
 					{
-					*retsError = strPatternSubst(CONSTLIT("Unable to find adventure: %08x."), Ctx.dwAdventure);
+					if (!retsError)
+						{
+						*retsError = strPatternSubst(CONSTLIT("Unable to find adventure: %08x."), Ctx.dwAdventure);
+						}
 					return ERR_FAIL;
 					}
 				}


### PR DESCRIPTION
…r if retsError is not set, otherwise leave that error msg intact

https://ministry.kronosaur.com/record.hexm?id=104000