### PR TITLE
Fix/102775 dont assume pilgrim

### DIFF
--- a/Transcendence/TransCore/Antarctica02.xml
+++ b/Transcendence/TransCore/Antarctica02.xml
@@ -446,12 +446,18 @@
 						(list { textID: 'textUnderAttack } )
 
 					(= (msnGetData gSource 'msgProgress) 'alreadyDebriefed)
-						(list { textID: 'AlreadyDebriefed } )
+						(list { textID: (if (rpgEqPlayerClass &unidPilgrimClass;)
+							'AlreadyDebriefedPilgrim
+							'AlreadyDebriefed
+							)})
 
 					(= (msnGetData gSource 'msgProgress) 'success)
 						(list
 							{ textID: 'textSuccessDebrief1 }
-							{ textID: 'textSuccessDebrief2 }
+							{ textID: (if (rpgEqPlayerClass &unidPilgrimClass;)
+								'textSuccessDebrief2Pilgrim
+								'textSuccessDebrief2
+								)}
 							{ textID: 'textSuccessDebrief3 }
 							)
 					)
@@ -561,10 +567,17 @@
 				"We did it! When we get back to St. Katharine's we will
 				bring the Ares peace plan to the Commonwealth!"
 			</Text>
-			<Text id="textSuccessDebrief2">
+			<Text id="textSuccessDebrief2Pilgrim">
 				"I know that your path lies elsewhere and that your journey
 				is just beginning. Thank you for helping us in our need.
 				In return, I want you to have this. It may help you someday."
+
+				And with that, Captain Helios places a small glowing gem in your hand.
+			</Text>
+			<Text id="textSuccessDebrief2">
+				"I know that your path lies elsewhere, but thank you for
+				helping us in our time of need. In return, I want you to
+				have this. It may help you someday."
 
 				And with that, Captain Helios places a small glowing gem in your hand.
 			</Text>
@@ -586,11 +599,17 @@
 			<Text id="textUnderAttack">
 				The captain is on the bridge directing the battle. She looks at you only briefly.
 			</Text>
-			<Text id="AlreadyDebriefed">
+			<Text id="AlreadyDebriefedPilgrim">
 				The captain of the CSC Antarctica welcomes you aboard:
 
 				"%Name%! It's good to see you again. We're heading back to St. Katharine's.
 				I know your journey is just beginning, but maybe we'll see each other there someday."
+			</Text>
+			<Text id="AlreadyDebriefed">
+				The captain of the CSC Antarctica welcomes you aboard:
+
+				"%Name%! It's good to see you again. We're heading back to St. Katharine's.
+				I know you have other places to be, but maybe we'll see each other there someday."
 			</Text>
 			<Text id="textRefuseDock">
 				As you exit the docking ramp, troopers train their weapons on you:

--- a/Transcendence/TransCore/AntarcticaD01.xml
+++ b/Transcendence/TransCore/AntarcticaD01.xml
@@ -217,7 +217,10 @@
 						(= status 'betrayed)
 							(list
 								{ textID: 'textBetrayed1 }
-								{ textID: 'textBetrayed2 }
+								{ textID: (if (rpgEqPlayerClass &unidPilgrimClass;)
+									'textBetrayed2Pilgrim
+									'textBetrayed2
+									)}
 								)
 
 						(= status 'destroyedByPlayer)
@@ -231,7 +234,10 @@
 								{ textID: 'textSuccess1 }
 								{ textID: (if (geq (objGetData gPlayerShip 'fleetLevel) 6)
 									'textSuccessCaptain2
-									'textSuccess2
+									(if (rpgEqPlayerClass &unidPilgrimClass;)
+										'textSuccess2Pilgrim
+										'textSuccess2
+										)
 									)}
 								)
 
@@ -377,23 +383,37 @@
 				weapon&mdash;something that will win this war. I want you to test
 				it. Report to the dockmaster and he will explain. Good luck!"
 			</Text>
-			<Text id="textSuccess2">
+			<Text id="textSuccess2Pilgrim">
 				"Thanks for tracking down the Antarctica&mdash;we couldn't have
 				done it without you. I know you're on your way to the Core,	but
 				if you stay with the Fleet and make captain, I guarantee that
 				I'll remember your service. Good luck, and remember what I said."
+			</Text>
+			<Text id="textSuccess2">
+				"Thanks for tracking down the Antarctica&mdash;we couldn't have
+				done it without you. If you stay with the Fleet and make captain,
+				I guarantee that I'll remember your service. Good luck, and
+				remember what I said."
 			</Text>
 			<Text id="textBetrayed1">
 				The bridge grows quiet as you enter. All the officers stare at
 				you, some with disgust, others with pity. The XO walks up to you:
 				"The admiral is waiting for you in his quarters."
 			</Text>
-			<Text id="textBetrayed2">
+			<Text id="textBetrayed2Pilgrim">
 				The admiral sits at his desk quietly studying you. He says,
 				
 				"You're a cold-blooded killer, do you know that? I heard how you
 				betrayed Captain Helios. I know she deserved it, but I'm glad
 				that you're leaving Human Space. I'll see you in hell."
+			</Text>
+			<Text id="textBetrayed2">
+				The admiral sits at his desk quietly studying you. He says,
+				
+				"You're a cold-blooded killer, do you know that? I heard how you
+				betrayed Captain Helios. I know she deserved it, but even with
+				stakes this high, I wouldn't have stooped so low. Get out of my
+				sight&mdash;I'll see you in hell."
 			</Text>
 		</Language>
 	</MissionType>

--- a/Transcendence/TransCore/AntarcticaD01.xml
+++ b/Transcendence/TransCore/AntarcticaD01.xml
@@ -166,7 +166,7 @@
 				(list
 					{	textID: 'textIntro1	}
 					{	textID: 'textIntro2	}
-					{	textID: (if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					{	textID: (if (rpgEqPlayerClass &unidPilgrimClass;)
 							'textIntro3Pilgrim
 							'textIntro3
 							)

--- a/Transcendence/TransCore/BenedictStoryArc.xml
+++ b/Transcendence/TransCore/BenedictStoryArc.xml
@@ -29,7 +29,7 @@
 				(switch
 					;	If we're not a pilgrim, then nothing to do.
 						
-					(not (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;))
+					(not (rpgEqPlayerClass &unidPilgrimClass;))
 						Nil
 							
 					;	If we're in the starting system, and if we dock with a Sisters

--- a/Transcendence/TransCore/Commonwealth.xml
+++ b/Transcendence/TransCore/Commonwealth.xml
@@ -1182,7 +1182,7 @@
 				(append
 					(rpgRumorAdd 'commonwealthHabitat (make 'sequence 4))
 
-					(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(if (rpgEqPlayerClass &unidPilgrimClass;)
 						(rpgRumorAdd 'commonwealthHabitat 'pilgrim)
 						(rpgRumorAdd 'commonwealthHabitat 'freelancer)
 						)

--- a/Transcendence/TransCore/CommonwealthFleetMissionPJ01.xml
+++ b/Transcendence/TransCore/CommonwealthFleetMissionPJ01.xml
@@ -598,7 +598,7 @@
 			<Text id="Briefing">
 				(list
 					{
-						textID: (if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+						textID: (if (rpgEqPlayerClass &unidPilgrimClass;)
 							'textBriefing1aPilgrim
 							'textBriefing1aNormal
 							)
@@ -658,7 +658,7 @@
 			</Text>
 
 			<Text id="SuccessDebrief">
-				(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+				(if (rpgEqPlayerClass &unidPilgrimClass;)
 					{	textID: 'textSuccessDebriefPilgrim	}
 					{	textID: 'textSuccessDebriefNormal	}
 					)

--- a/Transcendence/TransCore/CommonwealthMilitia.xml
+++ b/Transcendence/TransCore/CommonwealthMilitia.xml
@@ -594,7 +594,7 @@
 				(append
 					(rpgRumorAdd 'commonwealthMilitiaOC (make 'sequence 8))
 
-					(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(if (rpgEqPlayerClass &unidPilgrimClass;)
 						(rpgRumorAdd 'commonwealthMilitiaOC (make 'sequence 21 23))
 						(rpgRumorAdd 'commonwealthMilitiaOC (make 'sequence 41 43))
 						)

--- a/Transcendence/TransCore/CommonwealthMining.xml
+++ b/Transcendence/TransCore/CommonwealthMining.xml
@@ -400,7 +400,7 @@
 
 					(rpgRumorAdd 'commonwealthMining (make 'sequence 15))
 
-					(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(if (rpgEqPlayerClass &unidPilgrimClass;)
 						(rpgRumorAdd 'commonwealthMining 'pilgrim)
 						(rpgRumorAdd 'commonwealthMining 'freelancer)
 						)

--- a/Transcendence/TransCore/ContainerHabitat.xml
+++ b/Transcendence/TransCore/ContainerHabitat.xml
@@ -260,7 +260,7 @@
 					<Default>
 						<OnPaneInit>
 							(switch
-								(eq (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+								(rpgEqPlayerClass &unidPilgrimClass;)
 									(scrSetDescTranslate gScreen 'descWelcomePilgrim)
 									
 								(scrSetDescTranslate gScreen 'descWelcome)

--- a/Transcendence/TransCore/Dall01.xml
+++ b/Transcendence/TransCore/Dall01.xml
@@ -125,7 +125,7 @@
 					})
 			</Text>
 			<Text id="Intro">
-				(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+				(if (rpgEqPlayerClass &unidPilgrimClass;)
 					(msnTranslate gSource 'dallWelcomePilgrim)
 					(msnTranslate gSource 'dallWelcome)
 					)

--- a/Transcendence/TransCore/Domina.xml
+++ b/Transcendence/TransCore/Domina.xml
@@ -839,7 +839,7 @@
 					(switch
 						;	Must be a pilgrim
 
-						(!= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+						(!= (rpgGetPlayerClass) &unidPilgrimClass;)
 							'notPilgrim
 
 						;	Do not show powers that are above our level
@@ -1056,7 +1056,7 @@
 				(block (level)
 					(if (not (setq level (typGetGlobalData &stDomina; "level")))
 						(block Nil
-							(if (eq (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+							(if (rpgEqPlayerClass &unidPilgrimClass;)
 								(setq level 1)
 								(setq level 0)
 								)
@@ -1083,7 +1083,7 @@
 				(block (lastInvokeTime)
 					(switch
 						; Must be a pilgrim
-						(not (eq (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;))
+						(!= (rpgGetPlayerClass) &unidPilgrimClass;)
 							Nil
 						
 						; Always show level 1 power (sustain)

--- a/Transcendence/TransCore/FirstContactMonument.xml
+++ b/Transcendence/TransCore/FirstContactMonument.xml
@@ -153,7 +153,7 @@
 			<GetRumors>
 				(append
 					(rpgRumorAdd 'iocrymMonumentPub (make 'sequence 1 6) 20)
-					(if (eq (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(if (rpgEqPlayerClass &unidPilgrimClass;)
 						(rpgRumorAdd 'iocrymMonumentPub 'pilgrim.1 20)
 						(rpgRumorAdd 'iocrymMonumentPub 'quarantine.1 20)
 						)

--- a/Transcendence/TransCore/Pilgrim.xml
+++ b/Transcendence/TransCore/Pilgrim.xml
@@ -30,7 +30,7 @@
 							
 						;	If we're a Pilgrim, then we're at least level 1.
 						
-						(= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+						(rpgEqPlayerClass &unidPilgrimClass;)
 							1
 							
 						;	Otherwise Nil

--- a/Transcendence/TransCore/PointJuno.xml
+++ b/Transcendence/TransCore/PointJuno.xml
@@ -168,7 +168,7 @@
 
 			<Text id="descNoMissions">
 				(switch
-					(= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(rpgEqPlayerClass &unidPilgrimClass;)
 						(objTranslate gSource 'descNoMissionsPilgrim)
 					
 					(objTranslate gSource 'descNoMissionsNormal)

--- a/Transcendence/TransCore/Psych01.xml
+++ b/Transcendence/TransCore/Psych01.xml
@@ -84,6 +84,11 @@
 					(!= (objGetID aOwnerObj) (typ@ gType 'stationID))
 						Nil
 
+					;	Must be a pilgrim
+					
+					(!= (rpgGetPlayerClass) &unidPilgrimClass;)
+						Nil
+
 					True
 					)
 

--- a/Transcendence/TransCore/RPGCode.xml
+++ b/Transcendence/TransCore/RPGCode.xml
@@ -2562,6 +2562,25 @@
 					(objAddItem storageObj theItem)
 					)
 				))
+
+			;	CHARACTER CLASS FUNCTIONS ------------------------------------------------------------------
+			;
+			;	To implement:
+			;
+			;	1.	Define class design type (generic Type), and set on starting ship (to be deprecated)
+			;	2.	To get player class use rpgGetPlayerClass
+			;	3.	To check player class equivalence use rpgEqPlayerClass classUNID
+			;	4.	To set player class (this is not yet implemented)
+			;
+
+			(setq rpgGetPlayerClass (lambda ()
+				(objGetProperty gPlayerShip 'characterClass)
+				))
+
+			(setq rpgEqPlayerClass (lambda (unidCharacterClass)
+				(= (rpgGetPlayerClass) unidCharacterClass)
+				))
+
 			)
 	</Globals>
 

--- a/Transcendence/TransCore/Sanctuary.xml
+++ b/Transcendence/TransCore/Sanctuary.xml
@@ -98,7 +98,7 @@
 
 								;	No Sanctum if you're not a pilgrim
 
-								(if (!= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+								(if (!= (rpgGetPlayerClass) &unidPilgrimClass;)
 									(scrShowAction gScreen 'actionSanctum Nil)
 									)
 								)

--- a/Transcendence/TransCore/Sisters01.xml
+++ b/Transcendence/TransCore/Sisters01.xml
@@ -47,7 +47,7 @@
 				(switch
 					;	Player must be a Pilgrim
 					
-					(!= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(!= (rpgGetPlayerClass) &unidPilgrimClass;)
 						Nil
 						
 					;	Must be an enemy station in the system

--- a/Transcendence/TransCore/SistersOfDomina.xml
+++ b/Transcendence/TransCore/SistersOfDomina.xml
@@ -103,7 +103,7 @@
 
 			<Code id="statusDisplay">
 				(switch
-					(= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+					(rpgEqPlayerClass &unidPilgrimClass;)
 						(typTranslate &unidPilgrimClass; 'rankDetails)
 
 					(typTranslate gType 'nonPilgrimStatus)
@@ -297,7 +297,7 @@
 
 								;	No Sanctum if you're not a pilgrim
 
-								(if (!= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+								(if (!= (rpgGetPlayerClass) &unidPilgrimClass;)
 									(scrShowAction gScreen 'actionSanctum Nil)
 									)
 								)
@@ -336,7 +336,7 @@
 				(block (communionItem)
 					(append
 						(if (and (setq communionItem (random (objGetItems gPlayerShip "*U +communion;")))
-								(= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+								(rpgEqPlayerClass &unidPilgrimClass;)
 								)
 							(rpgRumorAdd 'sistersMission 'offerItem 100 nil {
 								itemName: (itmGetName communionItem 'article)
@@ -371,7 +371,7 @@
 					(objTranslate gSource 'descAbbessAdviceIntro)
 					"\n\n"
 					(switch
-						(= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+						(rpgEqPlayerClass &unidPilgrimClass;)
 							(objTranslate gSource (cat 'descAbbessAdvice (min (sysGetLevel) 7)))
 
 						(objTranslate gSource 'descAbbessAdvice.nonPilgrim)

--- a/Transcendence/TransCore/SistersPilgrimsAid.xml
+++ b/Transcendence/TransCore/SistersPilgrimsAid.xml
@@ -22,7 +22,7 @@
 			<Default>
 				<OnPaneInit>
 					(switch
-						(= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+						(rpgEqPlayerClass &unidPilgrimClass;)
 							(scrSetDesc gScreen (typTranslate &dsSistersDockServices; 'Welcome))
 
 						(block ()							

--- a/Transcendence/TransCore/SistersSanctum.xml
+++ b/Transcendence/TransCore/SistersSanctum.xml
@@ -80,7 +80,7 @@
 							
 								;	If we're not a Pilgrim, we always get nothing
 								
-								(!= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+								(!= (rpgGetPlayerClass) &unidPilgrimClass;)
 									(scrShowPane gScreen 'Nothing)
 									
 								;	If interval has not passed, then nothing
@@ -463,7 +463,7 @@
 
 							(or (not entry) 
 									(= rel 0)
-									(!= (obj@ gPlayerShip 'characterClass) &unidPilgrimClass;)
+									(!= (rpgGetPlayerClass) &unidPilgrimClass;)
 									)
 								(scrSetDescTranslate gScreen 'descDonate.nothing)
 

--- a/Transcendence/TransCore/Volkov.xml
+++ b/Transcendence/TransCore/Volkov.xml
@@ -280,7 +280,7 @@
 			<Text id="WingmanKilled">			Helena, I will join you now!</Text>
 
 			<Text id="Intro">
-				(if (= (objGetProperty gPlayerShip 'characterClass) &unidPilgrimClass;)
+				(if (rpgEqPlayerClass &unidPilgrimClass;)
 					(cat
 						"As the crowd breaks up, a tall man in a faded flight suit walks up to you:\n\n"
 						"\"My name is Volkov. You are going to the Core, is true? "


### PR DESCRIPTION
The reason for changing the player class detection code to a lambda is that it gives us the option to change the logic in one place, when it gets decoupled from the starting ship selection