### PR TITLE
fix: 104101: correctly use DestTable instead of only overwriting m_ArmorDamageAdj regardless if shields or armor are being overwritten

### DIFF
--- a/Mammoth/TSE/CEngineOptions.cpp
+++ b/Mammoth/TSE/CEngineOptions.cpp
@@ -139,7 +139,7 @@ bool CEngineOptions::InitDamageAdjFromXML (SDesignLoadCtx &Ctx, const CXMLElemen
 		return false;
 		}
 
-	if (m_ArmorDamageAdj[iLevel - 1].InitFromXML(Ctx, XMLDesc, true) != NOERROR)
+	if (DestTable[iLevel - 1].InitFromXML(Ctx, XMLDesc, true) != NOERROR)
 		return false;
 
 	//	Success!


### PR DESCRIPTION
fix: 104101: correctly use DestTable instead of only overwriting m_ArmorDamageAdj regardless if shields or armor are being overwritten