### PR TITLE
Fix: 104160: correctly use vMissileTravel which is relative to the pr…

### DIFF
--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -5324,7 +5324,7 @@ CSpaceObject* CSpaceObject::HitTestProximity(
 			if (iSteps == 0)
 				{
 				iSteps = (int)(rMissileTravel / (2.0 * g_KlicksPerPixel)) + 1;
-				vStep = vEnd / iSteps;
+				vStep = vMissileTravel / iSteps;
 				}
 
 			//	Check if we hit it directly


### PR DESCRIPTION
…ojectile to compute vStep instead of vEnd which is relative to the system in the new code

https://ministry.kronosaur.com/record.hexm?id=104160
(actual details)
https://ministry.kronosaur.com/record.hexm?id=104161