### PR TITLE
feat: 104233: add a better ui for regen delay (display in actual seconds)

### DIFF
--- a/Mammoth/TSE/CShieldClass.cpp
+++ b/Mammoth/TSE/CShieldClass.cpp
@@ -1800,26 +1800,15 @@ CString CShieldClass::OnGetReference (CItemCtx &Ctx, const CItem &Ammo, DWORD dw
 	else
 		sReference = strPatternSubst("regen @ %s", CLanguage::ComposeNumber(CLanguage::numberRegenRate, rRegen));
 
-	//	If we have a non-standard depletion delay, show that.
+	//	Show time to recover when depleted
 
-	if (m_iDepletionTicks != STD_DEPLETION_DELAY && rRegen > 0.0)
-		{
-		int iPercent = GetReferenceDepletionDelay();
-		if (iPercent == 0)
-			AppendReferenceString(&sReference, CONSTLIT("instant recovery time"));
-		else if (iPercent >= 100)
-			{
-			int iMultiple10 = mathRound(10.0 * (iPercent + 100.0) / 100.0);
-			if ((iMultiple10 % 10) == 0)
-				AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d%&times; longer recovery"), iMultiple10 / 10));
-			else
-				AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d.%d%&times; longer recovery"), iMultiple10 / 10, iMultiple10 % 10));
-			}
-		else if (iPercent > 0)
-			AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d%% longer recovery"), iPercent));
-		else
-			AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d%% shorter recovery"), -iPercent));
-		}
+	int iDepletionMultiple = mathRound(((Metric)m_iDepletionTicks / g_TicksPerSecond) * 10);
+	int iDepletion = iDepletionMultiple / 10;
+	int iDepletionRemainder = iDepletionMultiple % 10;
+	if (iDepletionRemainder)
+		AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d.%d sec recovery"), iDepletion, iDepletionRemainder));
+	else
+		AppendReferenceString(&sReference, strPatternSubst(CONSTLIT("%d sec recovery"), iDepletion));
 
 	return sReference;
 	}


### PR DESCRIPTION
Display in seconds rather than relative % to a mysterious hidden number