### PR TITLE
fix: 54869: add damage stat to urak howitzer so projectile size is pr…

### DIFF
--- a/Transcendence/TransCore/UrakWarlords.xml
+++ b/Transcendence/TransCore/UrakWarlords.xml
@@ -549,6 +549,7 @@
 
 		<Weapon
 				type=				"missile"
+				damage=				"blast:5d12"
 
 				fireRate=			"36"
 				missileSpeed=		"50"


### PR DESCRIPTION
…operly scaled (weapon does its damage via fragments and still appropriately displays stat card for fragment damage)