### PR TITLE
feat: 104243: add plyGetName 

### DIFF
--- a/Transcendence/Transcendence/CodeChainExtensions.cpp
+++ b/Transcendence/Transcendence/CodeChainExtensions.cpp
@@ -52,6 +52,7 @@ ICCItem *fnScrItem (CEvalContext *pEvalCtx, ICCItem *pArguments, DWORD dwData);
 #define FN_PLY_INC_ITEM_STAT		24
 #define FN_PLY_GET_SYSTEM_STAT		25
 #define FN_PLY_INC_SYSTEM_STAT		26
+#define FN_PLY_GET_NAME				27
 
 ICCItem *fnPlyGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData);
 ICCItem *fnPlyGetOld (CEvalContext *pEvalCtx, ICCItem *pArguments, DWORD dwData);
@@ -506,6 +507,10 @@ static PRIMITIVEPROCDEF g_Extensions[] =
 			"   'useItemHint\n",
 
 			"is",	0, },
+
+		{	"plyGetName",				fnPlyGet,		FN_PLY_GET_NAME,
+			"(plyGetName player) -> player's name",
+			"i",	0,	},
 
 		{	"plyGetCredits",				fnPlyGet,		FN_PLY_CREDITS,
 			"(plyGetCredits player [currency]) -> credits left",
@@ -1091,6 +1096,10 @@ ICCItem *fnPlyGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 
 	switch (dwData)
 		{
+		case FN_PLY_GET_NAME:
+			pResult = pCC->CreateString(pPlayer->GetPlayerName());
+			break;
+
 		case FN_PLY_CREDITS:
 			{
 			const CEconomyType *pEcon = GetEconomyTypeFromItem(*pCC, (pArgs->GetCount() > 1 ? pArgs->GetElement(1) : NULL));


### PR DESCRIPTION
so you dont need to inefficiently use (fmtCompose "%name%") anymore