### PR TITLE
Update RPGMembership

### DIFF
--- a/Transcendence/TransCore/RPGMembership.xml
+++ b/Transcendence/TransCore/RPGMembership.xml
@@ -11,8 +11,8 @@
 
 	The membership type (usually the sovereign) must have the following elements:
 
-	RankTable (StaticData): We expect this to be a struct of ranks, indexed by ranks
-		(starting at 1), and containing an xpNeeded field.
+	rankTable (Definition): We expect this to be a struct (or list) of ranks, indexed
+		by rank, and containing an xpNeeded field.
 
 	rpg.descPromotion: This series of language elements should define the
 		text shown to the player when they are promoted to a given rank (starting
@@ -24,6 +24,14 @@
 
 	rpg.xp: This is the player's current XP.
 
+	EVENTS
+
+	CheckPromotion: If present this even can provide custom promotion criteria to
+		be used instead of XP.
+
+	OnPromotion: This event will be called from the promotion screen. Allowing additional
+		rewards (e.g. military ID) to be given to the player.
+
 -->
 
 <!-- DOCK SCREENS -->
@@ -32,6 +40,12 @@
 			inherit=			"&dsDockScreenBase;"
 			nestedScreen=		"true"
 			>
+		<Display type="detailsPane">
+			<OnDisplayInit>
+				(or (@ gData 'rankDetails) (objTranslate gSource 'rpg.statusDetails))
+			</OnDisplayInit>
+		</Display>
+
 		<Panes>
 			<Default>
 				<OnPaneInit>
@@ -39,6 +53,8 @@
 						(membership (@ gData 'membership))
 						(newRank (rpgIsPromoted membership))
 						)
+
+						(typSet@ membership 'rpg.rank newRank)
 						(scrSetDesc gScreen (typTranslate membership "rpg.descPromotion" {
 							sourceObj: gSource
 							membership: membership
@@ -49,11 +65,8 @@
 
 				<Actions>
 					<Action id="actionContinue">
-						(block (
-							(membership (@ gData 'membership))
-							(newRank (rpgIsPromoted membership))
-							)
-							(typSetData membership 'rpg.rank newRank)
+						(block Nil
+							(typFireEvent (@ gData 'membership) 'OnPromotion)
 							(scrExitScreen gScreen)
 							)
 					</Action>
@@ -67,13 +80,26 @@
 	<Globals>
 	(block ()
 		(setq rpgIsPromoted (lambda (membership)
+			;	Check if the player should be promoted, returning their new rank (or Nil)
 			(block (
-				(rank (or (typGetData membership 'rpg.rank) 1))
-				(xp (or (typGetData membership 'rpg.xp) 0))
-				(rankTable (typGetStaticData membership 'RankTable))
-				(nextRankDesc (@ rankTable (+ rank 1)))
+				(rank (or (typ@ membership 'rpg.rank) 0))
+				(xp (or (typ@ membership 'rpg.xp) 0))
+				(rankTable (typ@ membership 'rankTable))
+				(nextRank (or (@ (@ rankTable rank) 'nextRank) (+ rank 1)))
+				(nextRankDesc (@ rankTable nextRank))
 				)
+
 				(switch
+					;	Use the custom event if it exists
+
+					(typHasEvent membership 'CheckPromotion)
+						(typFireEvent membership 'CheckPromotion)
+
+					;	If we previously had no rank (Nil) then promote to rank zero
+
+					(not (typ@ membership 'rpg.rank))
+						rank
+
 					;	If no rank table of if we're already at the highest
 					;	rank, then no promotion.
 
@@ -93,11 +119,11 @@
 			))
 
 		(setq rpgMissionRewardXP (lambda (membership xpReward missionObj)
-			(block (promotionScreen)
+			(block Nil
 
 				;	Increment XP
 
-				(typIncData membership 'rpg.xp xpReward)
+				(typInc@ membership 'rpg.xp xpReward)
 
 				;	If we're debriefing a mission, and we've been promoted,
 				;	then set the appropriate promotion screen.

--- a/Transcendence/TransCore/RPGMissions.xml
+++ b/Transcendence/TransCore/RPGMissions.xml
@@ -1364,9 +1364,9 @@
 
 			(setq rpgMissionRewardPayment (lambda (theReward currency)
 				(block Nil
-					(plyCredit gPlayer (or currency 'credit) theReward)
-					(typIncGlobalData &svPlayer; "missionRewards" 
-						(ecoExchange theReward (or currency 'credit) (unvGetProperty 'defaultCurrency))
+					(plyCredit gPlayer currency theReward)
+					(typInc@ &unidPlayer; 'missionRewards
+						(ecoExchange theReward currency (unv@ 'defaultCurrency))
 						)
 					)
 				))

--- a/Transcendence/TransCore/RPGPlayer.xml
+++ b/Transcendence/TransCore/RPGPlayer.xml
@@ -23,10 +23,14 @@
 	<Type unid="&unidPlayer;"
 			inherit="&unidCommonText;"
 			>
+		<Properties>
+			<Global id="missionRewards"></Global>
+		</Properties>
+
 		<Events>
 			<GetGlobalAchievements>
 				(block (
-					(missionRewards (typGetData &svPlayer; 'missionRewards))
+					(missionRewards (typ@ gType 'missionRewards))
 					)
 					(append
 
@@ -57,15 +61,26 @@
 			</GetGlobalAchievements>
 
 			<OnGlobalUniverseLoad>
-				; If we're loading because of a resurrect, repair the ship
+				(block Nil
+					;	Transistion from global data to property
 
-				(if (= aReason 'resurrect)
-					(block Nil
-						; Put the player in a safe place and repair the ship
-						(rpgRestorePlayer)
+					(if (typGetData &svPlayer; 'missionRewards)
+						(block Nil
+							(typSet@ gType 'missionRewards (typGetData &svPlayer; 'missionRewards))
+							(typSetData &svPlayer; 'missionRewards Nil)
+							)
+						)
 
-						; Tell the player about the resurrection
-						(plyMessage gPlayer (typTranslate gType 'msgResurrection))
+					; If we're loading because of a resurrect, repair the ship
+
+					(if (= aReason 'resurrect)
+						(block Nil
+							; Put the player in a safe place and repair the ship
+							(rpgRestorePlayer)
+
+							; Tell the player about the resurrection
+							(plyMessage gPlayer (typTranslate gType 'msgResurrection))
+							)
 						)
 					)
 			</OnGlobalUniverseLoad>


### PR DESCRIPTION
Updates RPGMembership to use properties and be slightly more flexible. This is intended for use in VotG, but it could also be used to simplify some of the Blackmarket / Militia / Fleet code in core.

* `rpg.rank` can start with a Nil value to indicate player is not a member, and rankDetails / achievements should not be shown. Any introduction code (or first call to rpgIsPromoted) should initialize rank to a non-Nil value
* `rankTable` may be a struct or list. If using a struct then we can use the "rankID" as the key e.g.
```
{
    volunteer:  { xpNeeded: 0  nextRank: 'lieutenant}
    lieutenant: { xpNeeded: 1000 nextRank: 'captain}
}
```
* If the membership type has a `CheckPromotion` event this will be used instead of the standard xp checks, allowing custom promotion rules (e.g. as used for Militia)
* dsRPGPromotion will call `OnPromotion` event on membership type so we can grant ROMs etc.

### rpgMissionRewardPayment 

Removes forcing of 'credit' as default currency so function will now use the adventure default. This will not affect SotP or EP, but will simplify some VotG code.

Change `missionRewards` to property

### Questions:
1. Should we rename rankTable to rpg.rankTable for consistency with other RPGLibrary code.
1. Would it be worth creating a generic membership type which can be inherited to define common properties e.g.
```xml
<Type UNID="&unidRPGMembership;" inherit="&unidCommonText;">
    <Properties>
        <Global id="rpg.rank"></Global>
        <Global id="rpg.xp">0</Global>
  
        <DynamicGlobal id="rpg.rankIcon">
            (block (
                (rank (typ@ gType 'rpg.rank))
                (rankTable (typ@ gType 'rpg.rankTable))
                )
                (@ (@ rankTable rank) 'icon)
                )
        </DynamicGlobal>
        <DynamicGlobal id="rpg.rankNoun">(typTranslate ...)</DynamicGlobal>
        <DynamicGlobal id="rpg.rankDetails">(block ...)</DynamicGlobal>
    <Properties>
</Type>
```

It would only save a bit of copy+past so may not be worth while.