### PR TITLE
fix 104291: sets the debug gameover timeout to normal, this was likel…

### DIFF
--- a/Transcendence/Transcendence/Transcendence.h
+++ b/Transcendence/Transcendence/Transcendence.h
@@ -39,7 +39,7 @@ extern CTranscendenceWnd *g_pTrans;
 #define TICKS_BEFORE_GATE					34
 #define TICKS_AFTER_GATE					30
 #ifdef DEBUG
-#define TICKS_AFTER_DESTROYED				12000
+#define TICKS_AFTER_DESTROYED				120
 #else
 #define TICKS_AFTER_DESTROYED				120
 #endif


### PR DESCRIPTION
…y a troubleshooting change that got left in since it never impacted the release builds

https://ministry.kronosaur.com/record.hexm?id=104291