### PR TITLE
Feature/104332 === operator

### DIFF
--- a/Alchemy/CodeChain/DefPrimitives.h
+++ b/Alchemy/CodeChain/DefPrimitives.h
@@ -148,6 +148,12 @@ static PRIMITIVEPROCDEF g_DefPrimitives[] =
 			"(= [x1 x2 ... xn]) -> True if all arguments are equal",
 			NULL, 0, },
 
+		{	"===",				fnEqualityExact, FN_EQUALITY_EQ,
+			"(=== [x1 x2 ... xn]) -> True if all arguments are exactly equal and of the same type\n"
+			"Treats strings as case sensitive. Does not treat zeros, empty lists, and strings as Nil\n"
+			"A single argument returns True if it is Nil.",
+			NULL, 0, },
+
 		{	"eval",				fnEval,			0,
 			"(eval exp) -> result\n\n"
 			
@@ -302,6 +308,12 @@ static PRIMITIVEPROCDEF g_DefPrimitives[] =
 
 		{	"!=",				fnEqualityNumerals,	FN_EQUALITY_NEQ,
 			"(!= x1 x2 ... xn) -> True if any arguments are not equal",
+			NULL, 0, },
+
+		{	"!===",				fnEqualityExact, FN_EQUALITY_NEQ,
+			"(!=== [x1 x2 ... xn]) -> True if any arguments are not equal or are of different types.\n"
+			"Treats strings as case sensitive. Does not treat zeros, empty lists, and strings as Nil\n"
+			"A single argument returns True if it is not Nil.",
 			NULL, 0, },
 
 		{	"not",				fnLogical,		FN_LOGICAL_NOT,

--- a/Alchemy/CodeChain/Functions.cpp
+++ b/Alchemy/CodeChain/Functions.cpp
@@ -5150,9 +5150,25 @@ int HelperCompareItems (ICCItem *pFirst, ICCItem *pSecond, DWORD dwCoerceFlags)
 		{
 		switch (pFirst->GetValueType())
 			{
-			case ICCItem::Nil:
 			case ICCItem::True:
 				return 0;
+
+			case ICCItem::Nil:
+				{
+				if (dwCoerceFlags & HELPER_COMPARE_COERCE_NONE)
+					{
+
+					//	empty lists report themselves as Nil, so we need to check if this is
+					//	truly CCNil which is a CCAtom, or a CCList which is not
+
+					if (pFirst->IsAtom())
+						return pSecond->IsAtom() ? 0 : -2;
+					else
+						return pSecond->IsAtom() ? -2 : 0;
+					}
+				else
+					return 0;
+				}
 
 			case ICCItem::Integer:
 				{

--- a/Alchemy/CodeChain/Functions.h
+++ b/Alchemy/CodeChain/Functions.h
@@ -117,6 +117,7 @@ ICCItem *fnCount (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnEnum (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnEquality (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnEqualityNumerals (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
+ICCItem *fnEqualityExact (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnEval (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnFilter (CEvalContext *pCtx, ICCItem *pArgs, DWORD dwData);
 ICCItem *fnFind (CEvalContext *pCtx, ICCItem *pArgs, DWORD dwData);

--- a/Alchemy/Include/CodeChain.h
+++ b/Alchemy/Include/CodeChain.h
@@ -995,6 +995,8 @@ ALERROR pageLibraryInit (CCodeChain &CC);
 
 #define HELPER_COMPARE_COERCE_COMPATIBLE		0x00000001
 #define HELPER_COMPARE_COERCE_FULL				0x00000002
+#define HELPER_COMPARE_COERCE_NONE				0x00000004
+#define HELPER_COMPARE_CASE_SENSITIVE			0x00000008
 
 int HelperCompareItems (ICCItem *pFirst, ICCItem *pSecond, DWORD dwCoerceFlags = HELPER_COMPARE_COERCE_COMPATIBLE);
 int HelperCompareItemsLists (ICCItem *pFirst, ICCItem *pSecond, int iKeyIndex, bool bCoerce = true);

--- a/Alchemy/Include/KernelString.h
+++ b/Alchemy/Include/KernelString.h
@@ -195,8 +195,8 @@ extern char g_LowerCaseAbsoluteTable[256];
 
 Kernel::CString strCat (const Kernel::CString &sString1, const Kernel::CString &sString2);
 int strCompare (const Kernel::CString &sString1, const Kernel::CString &sString2);
-int strCompareAbsolute (const Kernel::CString &sString1, const Kernel::CString &sString2);
-int strCompareAbsolute (LPCSTR pS1, LPCSTR pS2);
+int strCompareAbsolute (const Kernel::CString &sString1, const Kernel::CString &sString2, bool bCaseSensitive = false);
+int strCompareAbsolute (LPCSTR pS1, LPCSTR pS2, bool bCaseSensitive = false);
 Kernel::CString strConvert (const Kernel::CString &sText, DWORD dwFromCP, DWORD dwToCP);
 inline Kernel::CString strANSIToUTF8 (const Kernel::CString &sText) { return Kernel::strConvert(sText, CP_ACP, CP_UTF8); }
 inline Kernel::CString strUTF8ToANSI (const Kernel::CString &sText) { return Kernel::strConvert(sText, CP_UTF8, CP_ACP); }

--- a/Alchemy/Kernel/CString.cpp
+++ b/Alchemy/Kernel/CString.cpp
@@ -1022,12 +1022,16 @@ int Kernel::strCompare (const CString &sString1, const CString &sString2)
 		return 0;
 	}
 
-int Kernel::strCompareAbsolute (const CString &sString1, const CString &sString2)
+int Kernel::strCompareAbsolute (const CString &sString1, const CString &sString2, bool bCaseSensitive)
 
 //	strCompareAbsolute
 //
 //	Compares two strings are returns 1 if sString1 is > sString2; -1 if sString1
 //	is < sString2; and 0 if both strings are equal.
+// 
+//	Case sensitive operation prioritizes alphabetical order (ex, "a" < "B")
+//  however a capital letter is considered less than its lower case counterpart
+//	(ex, "A" < "a")
 //
 //	The resulting sort order does not change with locale. Use this only for
 //	internal sorting (e.g., symbol tables).
@@ -1047,13 +1051,25 @@ int Kernel::strCompareAbsolute (const CString &sString1, const CString &sString2
 
 	for (i = 0; i < iLen; i++)
 		{
-		char chChar1 = strLowerCaseAbsolute(*pPos1++);
-		char chChar2 = strLowerCaseAbsolute(*pPos2++);
+		char chChar1 = *pPos1++;
+		char chChar2 = *pPos2++;
+		char chCharLower1 = strLowerCaseAbsolute(chChar1);
+		char chCharLower2 = strLowerCaseAbsolute(chChar2);
 
-		if (chChar1 > chChar2)
-			return 1;
-		else if (chChar1 < chChar2)
-			return -1;
+		if (bCaseSensitive && chCharLower1 == chCharLower2)
+			{
+			if (chChar1 > chChar2)
+				return 1;
+			else if (chChar1 < chChar2)
+				return -1;
+			}
+		else
+			{
+			if (chCharLower1 > chCharLower2)
+				return 1;
+			else if (chCharLower1 < chCharLower2)
+				return -1;
+			}
 		}
 
 	//	If the strings match up to a point, check to see which is 
@@ -1067,17 +1083,29 @@ int Kernel::strCompareAbsolute (const CString &sString1, const CString &sString2
 		return 0;
 	}
 
-int Kernel::strCompareAbsolute (LPCSTR pS1, LPCSTR pS2)
+int Kernel::strCompareAbsolute (LPCSTR pS1, LPCSTR pS2, bool bCaseSensitive)
 	{
 	while (*pS1 != '\0' && *pS2 != '\0')
 		{
-		char chChar1 = strLowerCaseAbsolute(*pS1++);
-		char chChar2 = strLowerCaseAbsolute(*pS2++);
+		char chChar1 = *pS1++;
+		char chChar2 = *pS2++;
+		char chCharLower1 = strLowerCaseAbsolute(chChar1);
+		char chCharLower2 = strLowerCaseAbsolute(chChar2);
 
-		if (chChar1 > chChar2)
-			return 1;
-		else if (chChar1 < chChar2)
-			return -1;
+		if (bCaseSensitive && chCharLower1 == chCharLower2)
+			{
+			if (chChar1 > chChar2)
+				return 1;
+			else if (chChar1 < chChar2)
+				return -1;
+			}
+		else
+			{
+			if (chCharLower1 > chCharLower2)
+				return 1;
+			else if (chCharLower1 < chCharLower2)
+				return -1;
+			}
 		}
 
 	//	If the strings match up to a point, check to see if we hit

--- a/Mammoth/Include/TSEVersions.h
+++ b/Mammoth/Include/TSEVersions.h
@@ -336,6 +336,24 @@ constexpr DWORD SYSTEM_SAVE_VERSION =					213;
 //		tlisp:
 //			(plyGetName player)
 //				Allows getting the player name without needing to use str formatting
+//			(=== [a b ...])
+//				Exact equality operator, does not coerce any types and is case sensitive
+//				Can be used to test if a variable is a real empty list (mutable) or
+//				actually just Nil (atomic)
+//				If given 1 arg, compares that arg to Nil, returns True if (atomic) Nil
+//				WARNING, as this function may be used in performance sensitive code,
+//				it does not check that you are using API55 first. Ensure your API version
+//				is appropriately set to avoid multiverse from downloading your extension
+//				onto an incompatible version.
+//			(!=== [a b ...])
+//				Exact inequality operator, does not coerce any types and is case sensitive
+//				Can be used to test if a variable is a real empty list (mutable) or
+//				actually just Nil (atomic)
+//				If given 1 arg, compares that arg to Nil, returns True if not (atomic) Nil
+//				WARNING, as this function may be used in performance sensitive code,
+//				it does not check that you are using API55 first. Ensure your API version
+//				is appropriately set to avoid multiverse from downloading your extension
+//				onto an incompatible version.
 //		Any <Type>
 //			<AttributeDesc>
 //				<ItemAttribute> and <LocationAttribute>


### PR DESCRIPTION
https://ministry.kronosaur.com/record.hexm?id=104332

Also includes the !=== operator

Important notes:

1. This function is being treated as performance sensitive code due to planned use in some libraries such as TAI. It will NOT have the safety of an API version check, so ensure that you bump your API version if you use this function.
2. we can now test for an explicit atomic Nil. This is crucial for code that needs to test if it has been passed a real list it can operate in-place on, or a Nil, which it cannot.
3. This function is case sensitive. It treats "A" != "a".
4. explicit gt/lt/gte/lte versions are not included in this PR, but may be something we want to look at in the future for string comparisons as the case sensitive handling can work with that. Note: it would treat "A" < "a", and "a" < "B". This is in-line with alphabetical ordering priority used by both many modern OSes and the existing case insensitive versions, rather than the raw ASCII encoding, in which "A" < "a" but also "B" < "a".
5. [Ignore this, turns out the I misread the console while testing and thought (list) was returning Nil but it was returning an empty list] We may want to revisit the current practice of returning atomic Nil from ()/(list) instead of a mutable - nobody should be doing that to generate an atomic Nil, they should be using Nil instead. Even if we dont change it, we should have a way of directly generating a mutable empty list directly instead of doing `(setq myList (list 1)) (lnkRemove myList 0)`