### PR TITLE
Feature/104333-SotP_Mission_Library

### DIFF
--- a/Transcendence/TransCore/HuaramarcaLibrary.xml
+++ b/Transcendence/TransCore/HuaramarcaLibrary.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE TranscendenceLibrary
+	[
+	<!-- 0021 0000-FFFF Huaramarca Library -->
+	
+	<!ENTITY unidHuaramarcaLibrary 	    "0x00210000">
+
+	<!-- 0021xxxx HUARI ==================================================== -->
+	
+	<!ENTITY smHuariSpace				"0x00210001">
+	<!ENTITY msHuaramarcaTuali			"0x00210002">
+	<!ENTITY msHuaramarcaDreamTest		"0x00210003">
+	<!ENTITY msHuaramarcaDefendTemple	"0x00210004">
+	<!ENTITY msHuaramarcaAttackBase		"0x00210005">
+	<!ENTITY msHuaramarcaDragonSlaver	"0x00210006">
+	<!ENTITY msHuaramarcaArchcannon		"0x00210007">
+	<!ENTITY msHuaramarcaRevelation		"0x00210008">
+
+	]>
+	
+<TranscendenceLibrary
+		UNID=				"&unidHuaramarcaLibrary;"
+		name=				"Transcendence Huaramarca Library" 
+		release=			"1"
+		>
+
+	<Library unid="&unidCoreTypesLibrary;"/>
+	<Library unid="&unidRPGLibrary;"/>
+	<Library unid="&unidGalaxyLibrary;"/>
+	<Library unid="&unidHumanSpaceLibrary;"/>
+	<Library unid="&unidSOTPSoundtrackUNIDLibrary;"/>
+
+	<Module filename="Huaramarca.xml"/>
+	<Module filename="HuaramarcaMission01.xml"/>
+	<Module filename="HuaramarcaMission02.xml"/>
+	<Module filename="HuaramarcaMission03.xml"/>
+	<Module filename="HuaramarcaMission04.xml"/>
+	<Module filename="HuaramarcaMission05.xml"/>
+	<Module filename="HuaramarcaMission06.xml"/>
+	<Module filename="HuaramarcaMission07.xml"/>
+    
+</TranscendenceLibrary>

--- a/Transcendence/TransCore/StarsOfThePilgrim.xml
+++ b/Transcendence/TransCore/StarsOfThePilgrim.xml
@@ -12,73 +12,10 @@
 	<!-- HUMAN SPACE LIBRARY 0x00200003 -->
 	<!ENTITY unidPartISystemMap			"0x00200004">
 	<!ENTITY msReachGalacticCore		"0x00200005">
-	<!ENTITY unidBenedictStoryArc		"0x00200006">
-	<!ENTITY dsBenedictIntro			"0x00200007">
-	<!ENTITY msBenedictsDrones			"0x00200008">
-	<!ENTITY msBenedictAndFiona			"0x00200009">
-	<!-- UNUSED 0x0020000A -->
-	<!ENTITY msBenedictToKorolov		"0x0020000B">
-	<!ENTITY msBenedictTraining			"0x0020000C">
+	<!-- 0006 - 000C in Stories of the Pilgrim Library-->
 	<!ENTITY rsGalacticCoreMissionTile	"0x0020000D">
 	<!ENTITY unidAchievements			"0x0020000E">
-	
-	<!-- 0010-005F BENEDICT MISSION ARC -->
-	
-	<!ENTITY msBenedictInNewBeyond		"0x00200010">
-	<!ENTITY tbBenedict04Encounters		"0x00200011">
-	<!ENTITY msFionaInStKats			"0x00200012">
-	<!ENTITY msFindHandOfSolace			"0x00200013">
-	<!ENTITY stHandOfSolaceWreck		"0x00200014">
-	<!ENTITY ovBenedict05ScanRange		"0x00200015">
-	<!ENTITY tbBenedict05Encounters		"0x00200016">
-	<!ENTITY msInfiltratePenitents		"0x00200017">
-	<!ENTITY svBenedict06Infiltrate		"0x00200018">
-	<!ENTITY evBenedict06PenitentBase	"0x00200019">
-	<!ENTITY ovBenedict06Disarm			"0x0020001A">
-	<!ENTITY msRescueBenedict			"0x0020001B">
-	<!ENTITY evBenedict07PenitentWreck	"0x0020001C">
-	<!ENTITY msRescueChildrenFromPenitents	"0x0020001D">
-	<!ENTITY evBenedict08PenitentBase	"0x0020001E">
-	<!ENTITY evBenedict07FionaWreck		"0x0020001F">
-	<!ENTITY evBenedict06PenitentShip	"0x00200020">
-	<!ENTITY evBenedict07Wingman		"0x00200021">
-	<!ENTITY evBenedict02FionaWreck		"0x00200022">
-	<!ENTITY baBenedictMission			"0x00200023">
-	<!ENTITY rsBenedictMission			"0x00200024">
-	<!ENTITY evBenedict05ASandoval		"0x00200025">
-
-	<!-- 0060-007F HERETIC MISSION ARC -->
-	
-	<!ENTITY msHereticIocrymAttack		"0x00200060">
-	<!ENTITY msHereticIocrymAttackMsg	"0x00200061">
-	<!ENTITY msHereticSvalbard			"0x00200062">
-	<!ENTITY dsHereticSvalbardDonate	"0x00200063">
-	<!ENTITY msHereticControlPoint		"0x00200064">
-	<!ENTITY msHereticFurtherResearch	"0x00200065">
-	<!ENTITY msHereticSettlement		"0x00200066">
-	<!ENTITY msHereticMaryamsArchive	"0x00200067">
-	<!ENTITY stMaryamsArchive			"0x00200068">
-	<!ENTITY msHereticHuygensExplorer	"0x00200069">
-	<!ENTITY evHereticHuygensExplorer	"0x0020006A">
-	<!ENTITY msHereticIocrymArtifact	"0x0020006B">
-	<!ENTITY msHereticIocrymOutpost		"0x0020006C">
-	<!ENTITY msHereticMRADExperiment	"0x0020006D">
-
-	<!-- 0080-00BF MISCELLANEOUS MISSIONS -->
-
-	<!ENTITY msPsychEval01				"0x00200080">
-	<!ENTITY msPsychEval00				"0x00200081">
-
-	<!-- 0021xxxx HUARI ==================================================== -->
-	
-	<!ENTITY smHuariSpace				"0x00210001">
-	<!ENTITY msHuaramarcaTuali			"0x00210002">
-	<!ENTITY msHuaramarcaDreamTest		"0x00210003">
-	<!ENTITY msHuaramarcaDefendTemple	"0x00210004">
-	<!ENTITY msHuaramarcaAttackBase		"0x00210005">
-	<!ENTITY msHuaramarcaDragonSlaver	"0x00210006">
-	<!ENTITY msHuaramarcaArchcannon		"0x00210007">
-	<!ENTITY msHuaramarcaRevelation		"0x00210008">
+	<!-- 0010-00BF in Stories of the Pilgrim Library-->
 	]>
 	
 <TranscendenceAdventure
@@ -91,6 +28,8 @@
 	<Library unid="&unidRPGLibrary;"/>
 	<Library unid="&unidGalaxyLibrary;"/>
 	<Library unid="&unidHumanSpaceLibrary;"/>
+	<Library unid="&unidHuaramarcaLibrary;"/>
+	<Library unid="&unidSOTPMissionLibrary;"/>
 	<Library unid="&unidSOTPSoundtrackUNIDLibrary;"/>
 
 	<AdventureDesc
@@ -328,39 +267,9 @@
 	</AdventureDesc>
 		
 	<Module filename="Achievements.xml"/>
-	<Module filename="Benedict00.xml"/>
-	<Module filename="Benedict01.xml"/>
-	<Module filename="Benedict02.xml"/>
-	<!-- Benedict03 is obsolete. -->
-	<Module filename="Benedict04.xml"/>
-	<Module filename="Benedict05.xml"/>
-	<Module filename="Benedict05A.xml"/>
-	<Module filename="Benedict06.xml"/>
-	<Module filename="Benedict07.xml"/>
-	<Module filename="Benedict08.xml"/>
-	<Module filename="BenedictStoryArc.xml"/>
 	<Module filename="Elysium.xml"/>
-	<Module filename="Heretic00.xml"/>
-	<Module filename="Heretic01.xml"/>
-	<Module filename="Heretic02.xml"/>
-	<Module filename="Heretic03.xml"/>
-	<Module filename="Heretic04.xml"/>
-	<Module filename="Heretic05.xml"/>
-	<Module filename="Heretic06.xml"/>
-	<Module filename="Heretic07.xml"/>
-	<Module filename="Heretic08.xml"/>
-	<Module filename="Huaramarca.xml"/>
-	<Module filename="HuaramarcaMission01.xml"/>
-	<Module filename="HuaramarcaMission02.xml"/>
-	<Module filename="HuaramarcaMission03.xml"/>
-	<Module filename="HuaramarcaMission04.xml"/>
-	<Module filename="HuaramarcaMission05.xml"/>
-	<Module filename="HuaramarcaMission06.xml"/>
-	<Module filename="HuaramarcaMission07.xml"/>
 	<Module filename="Part1Compatibility.xml"/>
 	<Module filename="PlayerShips.xml"/>
-	<Module filename="Psych00.xml"/>
-	<Module filename="Psych01.xml"/>
 		
 <!-- ADVENTURE MAP -->
 

--- a/Transcendence/TransCore/StoriesOfThePilgrim.xml
+++ b/Transcendence/TransCore/StoriesOfThePilgrim.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE TranscendenceLibrary
+	[
+	<!-- 0022 0000-FFFF Stories of the Pilgrim (Part 1 Pilgrim missions) -->
+	
+	<!ENTITY unidSOTPMissionLibrary 	"0x00220000">
+
+    <!-- 0020 0006-000C Core/Compatibility -->
+	<!ENTITY unidBenedictStoryArc		"0x00200006">
+	<!ENTITY dsBenedictIntro			"0x00200007">
+	<!ENTITY msBenedictsDrones			"0x00200008">
+	<!ENTITY msBenedictAndFiona			"0x00200009">
+	<!-- UNUSED 0x0020000A -->
+	<!ENTITY msBenedictToKorolov		"0x0020000B">
+	<!ENTITY msBenedictTraining			"0x0020000C">
+	
+	<!-- 0010-005F BENEDICT MISSION ARC -->
+	
+	<!ENTITY msBenedictInNewBeyond		"0x00200010">
+	<!ENTITY tbBenedict04Encounters		"0x00200011">
+	<!ENTITY msFionaInStKats			"0x00200012">
+	<!ENTITY msFindHandOfSolace			"0x00200013">
+	<!ENTITY stHandOfSolaceWreck		"0x00200014">
+	<!ENTITY ovBenedict05ScanRange		"0x00200015">
+	<!ENTITY tbBenedict05Encounters		"0x00200016">
+	<!ENTITY msInfiltratePenitents		"0x00200017">
+	<!ENTITY svBenedict06Infiltrate		"0x00200018">
+	<!ENTITY evBenedict06PenitentBase	"0x00200019">
+	<!ENTITY ovBenedict06Disarm			"0x0020001A">
+	<!ENTITY msRescueBenedict			"0x0020001B">
+	<!ENTITY evBenedict07PenitentWreck	"0x0020001C">
+	<!ENTITY msRescueChildrenFromPenitents	"0x0020001D">
+	<!ENTITY evBenedict08PenitentBase	"0x0020001E">
+	<!ENTITY evBenedict07FionaWreck		"0x0020001F">
+	<!ENTITY evBenedict06PenitentShip	"0x00200020">
+	<!ENTITY evBenedict07Wingman		"0x00200021">
+	<!ENTITY evBenedict02FionaWreck		"0x00200022">
+	<!ENTITY baBenedictMission			"0x00200023">
+	<!ENTITY rsBenedictMission			"0x00200024">
+	<!ENTITY evBenedict05ASandoval		"0x00200025">
+
+	<!-- 0060-007F HERETIC MISSION ARC -->
+	
+	<!ENTITY msHereticIocrymAttack		"0x00200060">
+	<!ENTITY msHereticIocrymAttackMsg	"0x00200061">
+	<!ENTITY msHereticSvalbard			"0x00200062">
+	<!ENTITY dsHereticSvalbardDonate	"0x00200063">
+	<!ENTITY msHereticControlPoint		"0x00200064">
+	<!ENTITY msHereticFurtherResearch	"0x00200065">
+	<!ENTITY msHereticSettlement		"0x00200066">
+	<!ENTITY msHereticMaryamsArchive	"0x00200067">
+	<!ENTITY stMaryamsArchive			"0x00200068">
+	<!ENTITY msHereticHuygensExplorer	"0x00200069">
+	<!ENTITY evHereticHuygensExplorer	"0x0020006A">
+	<!ENTITY msHereticIocrymArtifact	"0x0020006B">
+	<!ENTITY msHereticIocrymOutpost		"0x0020006C">
+	<!ENTITY msHereticMRADExperiment	"0x0020006D">
+
+	<!-- 0080-00BF MISCELLANEOUS MISSIONS -->
+
+	<!ENTITY msPsychEval01				"0x00200080">
+	<!ENTITY msPsychEval00				"0x00200081">
+
+	]>
+	
+<TranscendenceLibrary
+		UNID=				"&unidSOTPMissionLibrary;"
+		name=				"Transcendence Stories of the Pilgrim" 
+		release=			"1"
+		>
+
+	<Library unid="&unidCoreTypesLibrary;"/>
+	<Library unid="&unidRPGLibrary;"/>
+	<Library unid="&unidGalaxyLibrary;"/>
+	<Library unid="&unidHumanSpaceLibrary;"/>
+	<Library unid="&unidSOTPSoundtrackUNIDLibrary;"/>
+
+	<Module filename="Benedict00.xml"/>
+	<Module filename="Benedict01.xml"/>
+	<Module filename="Benedict02.xml"/>
+	<!-- Benedict03 is obsolete. -->
+	<Module filename="Benedict04.xml"/>
+	<Module filename="Benedict05.xml"/>
+	<Module filename="Benedict05A.xml"/>
+	<Module filename="Benedict06.xml"/>
+	<Module filename="Benedict07.xml"/>
+	<Module filename="Benedict08.xml"/>
+	<Module filename="BenedictStoryArc.xml"/>
+	<Module filename="Heretic00.xml"/>
+	<Module filename="Heretic01.xml"/>
+	<Module filename="Heretic02.xml"/>
+	<Module filename="Heretic03.xml"/>
+	<Module filename="Heretic04.xml"/>
+	<Module filename="Heretic05.xml"/>
+	<Module filename="Heretic06.xml"/>
+	<Module filename="Heretic07.xml"/>
+	<Module filename="Heretic08.xml"/>
+	<Module filename="Psych00.xml"/>
+	<Module filename="Psych01.xml"/>
+    
+</TranscendenceLibrary>

--- a/Transcendence/TransCore/Transcendence.xml
+++ b/Transcendence/TransCore/Transcendence.xml
@@ -123,6 +123,10 @@
 	<!ENTITY unidPartISystemMap			"0x00200004">
 	
 	<!-- HUARI 0021 0xxx -->
+	<!ENTITY unidHuaramarcaLibrary 		"0x00210000">
+
+	<!-- PILGRIM STORY MISSIONS -->
+	<!ENTITY unidSOTPMissionLibrary 	"0x00220000">
 	
 	<!-- PART I SOUNDTRACK 0082 -->
 	]>
@@ -169,6 +173,8 @@
 	<CoreLibrary filename="GalaxyLibrary.xml"/>
 	<CoreLibrary filename="SOTPSoundtrackUNIDsLibrary.xml"/>
 	<CoreLibrary filename="HumanSpaceVol01.xml"/>
+	<CoreLibrary filename="HuaramarcaLibrary.xml"/>
+	<CoreLibrary filename="StoriesOfThePilgrim.xml"/>
 	<CoreLibrary filename="CompatibilityLibrary.xml"/>
 	<CoreLibrary filename="CMPT_API54CompatUNIDsLibrary.xml"/>
 


### PR DESCRIPTION
This PR encapsulates the changes for getting the Stars of the Pilgrim content available in other adventures (such as the planned combined trilogy adventure which initially will have Part 1 + 2 content combined.)

UNID namespaces:
0x0021 is for the huaramarca library
0x0022 is for the sotp stories (contains a bunch of 0x0020 UNIDs for compatibility reasons)

Note we need to figure out what to do with the remaining 4 modules.

Initial commit message:

Feat: 104333: separate out huaramarca content into HuaramarcaLibrary for use by other adventures (to be refactored later to support non pilgrim adventures). Separate out pilgrim storyline into StoriesOfThePilgrim library for use by the combined trilogy adventure. SotPPlayerships, elysium, part1 compat & achievements to be evaluated separately.