### PR TITLE
fix: 100991: altered Jenna's join and leave code

### DIFF
--- a/Transcendence/TransCore/CommonwealthMilitia.xml
+++ b/Transcendence/TransCore/CommonwealthMilitia.xml
@@ -511,6 +511,7 @@
 											;	If the player is a captain, they can meet Jenna
 											(and (= rank 2)
 												(not (typGetGlobalData &chJenna; 'status))
+												(leq (sysGetLevel) (typGetStaticData &chJenna; 'MaxSystemSpawnLevel))
 												(leq (random 1 100) 60)
 												)
 												(scrShowScreen gScreen &dsRPGWingmanEncounter; {wingman: &chJenna;})

--- a/Transcendence/TransCore/Jenna.xml
+++ b/Transcendence/TransCore/Jenna.xml
@@ -57,10 +57,8 @@
 		<StaticData>
 			<Name>Jenna</Name>
 			<Sovereign>&svCommonwealth;</Sovereign>
-
-			<!-- This is an optional field. If present, the wingman
-				will leave the player beyond a certain point. -->
-			<MaxSystemLevel>7</MaxSystemLevel>
+			<MaxSystemSpawnLevel>6</MaxSystemSpawnLevel>
+			<MaxSystemLevelsTravelled>2</MaxSystemLevelsTravelled>
 		</StaticData>
 		
 		<Language>

--- a/Transcendence/TransCore/RPGWingmen.xml
+++ b/Transcendence/TransCore/RPGWingmen.xml
@@ -344,7 +344,13 @@
 								)
 							(switch
 								; Some wingmen (like Jenna) doesn't want to proceed beyond a certain point
-								(and (setq maxSystemLevel (objGetStaticData gSource "MaxSystemLevel"))
+								; Preferentially check the level difference before checking maximum system level
+								(and (setq maxSystemLevel (or 
+											(if (and (objGetData gSource 'recruitmentSystemLevel) (objGetStaticData gSource "MaxSystemLevelsTravelled"))
+												(+ (objGetData gSource 'recruitmentSystemLevel) (objGetStaticData gSource "MaxSystemLevelsTravelled"))
+												)
+											(objGetStaticData gSource "MaxSystemLevel"))
+											)
 										(gr (sysGetLevel) maxSystemLevel)
 										)
 									(block Nil
@@ -832,6 +838,9 @@
 
 								(setq wingmanObj (sysCreateShip wingman gSource (typGetProperty wingman 'defaultSovereign)))
 								)
+							;   Get level of system when wingman is recruited
+							
+							(objSetData wingmanObj 'recruitmentSystemLevel (sysGetLevel))
 
 							;	Order them to follow the player
 


### PR DESCRIPTION
Started changing the logic for Jenna's start and leave time but have not been able to successfully test it since she dies quickly when attempting to trigger her leaving behavior. 
She now will travel two system levels max and only have a chance to spawn before level 6.