### PR TITLE
fix: 97840: level range on reactors with no level range displays inva…

### DIFF
--- a/Mammoth/TSE/CItemCriteria.cpp
+++ b/Mammoth/TSE/CItemCriteria.cpp
@@ -86,6 +86,13 @@ bool CItemCriteria::GetExplicitLevelMatched (int *retiMin, int *retiMax) const
 //	criteria are missing, we return -1.
 
 	{
+
+	//	First we set our defaults. We overwrite them if necessary, but we assume we dont need to display them.
+	//	min == -1 && max == -1 is used to disable displaying a fuel level range.
+
+	*retiMin = -1;
+	*retiMax = -1;
+
 	if (!m_sLookup.IsBlank())
 		{
 		const CItemCriteria *pCriteria = g_pUniverse->GetDesignCollection().GetDisplayAttributes().FindCriteriaByID(m_sLookup);
@@ -94,10 +101,19 @@ bool CItemCriteria::GetExplicitLevelMatched (int *retiMin, int *retiMax) const
 
 		return pCriteria->GetExplicitLevelMatched(retiMin, retiMax);
 		}
+
+	//	If we have a level range in the criteria, use that
+
 	else if (!m_LevelRange.IsEmpty())
 		return m_LevelRange.GetRange(retiMin, retiMax);
+
+	//	If we have a level range for repairs in the criteria, use that
+
 	else if (!m_RepairLevelRange.IsEmpty())
 		return m_RepairLevelRange.GetRange(retiMin, retiMax);
+
+	//	This criteria doesnt specify a level, so we dont display a levelrange (-1, -1)
+
 	else
 		return false;
 	}


### PR DESCRIPTION
…lid data instead of hiding that field

https://ministry.kronosaur.com/record.hexm?id=97840