### PR TITLE
fix: 104459: fix out of bounds condition when using lists (technically only impacted subset)

### DIFF
--- a/Alchemy/CodeChain/Functions.cpp
+++ b/Alchemy/CodeChain/Functions.cpp
@@ -4634,7 +4634,7 @@ ICCItem *fnSubset (CEvalContext *pCtx, ICCItem *pArgs, DWORD dwData)
 
 	//	This is the default not set value for subset iCount. slice iCount is always positive at this point in the code.
 	
-	if (iCount == -1)
+	if (iCount == -1 || (iStart + iCount) > iSourceCount)
 		iCount = iSourceCount - iStart;
 
 	//	Return nil or empty if asked to get a count of 0 or below

--- a/Transcendence/Game/TLisp/ListUnitTest.tlisp
+++ b/Transcendence/Game/TLisp/ListUnitTest.tlisp
@@ -53,7 +53,10 @@
 	{	code: '(subset (list 1 2 3 4) 5)						result: Nil}
 	{	code: '(subset (list 1 2 3 4) 5 5)						result: Nil}
 	{	code: '(subset (list 1 2 3 4) 2 5)						result: '(3 4)}
+	{	code: '(subset (list 1 2 3 4) -2 5 '-)					result: '(3 4)}
 	{	code: '(subset (list 1 2 3 4) 5 'empty)					result: '()}
+	{	code: '(subset (list 1 2 3 4) 5 5 'empty)				result: '()}
+	{	code: '(subset (list 1 2 3 4) 5 5 'empty '-)			result: '()}
 
 	;	Slice
 	

--- a/Transcendence/Game/TLisp/ListUnitTest.tlisp
+++ b/Transcendence/Game/TLisp/ListUnitTest.tlisp
@@ -51,6 +51,8 @@
 	{	code: '(subset (list 1 2 3 4) -3 2)						result: '(1 2)}
 	{	code: '(subset (list 1 2 3 4) -3 2 '-)					result: '(2 3)}
 	{	code: '(subset (list 1 2 3 4) 5)						result: Nil}
+	{	code: '(subset (list 1 2 3 4) 5 5)						result: Nil}
+	{	code: '(subset (list 1 2 3 4) 2 5)						result: '(3 4)}
 	{	code: '(subset (list 1 2 3 4) 5 'empty)					result: '()}
 
 	;	Slice
@@ -60,6 +62,7 @@
 	{	code: '(slice (list 1 2 3 4 5 6) -4 -2)					result: '(3 4 5)}
 	{	code: '(slice (list 1 2 3 4) 10 12)						result: '()}
 	{	code: '(slice (list 1 2 3 4) 2 1)						result: '()}
+	{	code: '(slice (list 1 2 3 4) 2 5)						result: '(3 4)}
 
 	))
 


### PR DESCRIPTION
This issue is causing shipbrokers to not work, since the improved shipbroker code deliberately makes calls to subset that are usually out of range.