### PR TITLE
feat: 104398: implement sprite painting chunked by scanlines

### DIFF
--- a/Mammoth/Include/TSEImages.h
+++ b/Mammoth/Include/TSEImages.h
@@ -249,7 +249,7 @@ class CObjectImageArray
 		bool IsLoaded (void) const { return (m_pImage != NULL); }
         bool IsMarked (void) const { return (m_pImage && m_pImage->IsMarked()); }
 		void MarkImage (void) const;
-		void PaintImage (CG32bitImage &Dest, int x, int y, int iTick, int iRotation, bool bComposite = false) const;
+		void PaintImage (CG32bitImage &Dest, int x, int y, int iTick, int iRotation, bool bComposite = false, SViewportPaintCtx *Ctx = NULL, int iOffsetY = -1, int iOffsetCY = -1) const;
 		void PaintImageGrayed (CG32bitImage &Dest, int x, int y, int iTick, int iRotation) const;
 		void PaintImageShimmering (CG32bitImage &Dest,
 								   int x,

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -5273,7 +5273,7 @@ void CShip::OnPaint (CG32bitImage &Dest, int x, int y, SViewportPaintCtx &Ctx)
 	else if (IsRadioactive())
 		Image.PaintImageWithGlow(Dest, x, y, Ctx.iTick, m_Rotation.GetFrameIndex(), CG32bitPixel(0, 255, 0));
 	else
-		Image.PaintImage(Dest, x, y, Ctx.iTick, m_Rotation.GetFrameIndex());
+		Image.PaintImage(Dest, x, y, Ctx.iTick, m_Rotation.GetFrameIndex(), false, &Ctx);
 
 	//	Paint effects in front of the ship.
 


### PR DESCRIPTION
At the default max of 16 threads, this nearly eliminates the paint lag from a bunch of ships or stations... however 2 important notes on its current form:

* This is not yet implemented for filtered sprite drawing (ex, radiation, stealth shimmer, etc)

* There are weird bugs with CThreadPool that can result in deadlocks or crashes:
* CThreadPool bug 1: it completely deadlocks and the completed event is never fired
* CThreadPool bug 2: it corrupts the heap while cleaning up tasks