### PR TITLE
104504: collapse damage types, 104505: fix 0% damage adj displaying in some cases (monopole shield)

### DIFF
--- a/Mammoth/Include/Painters.h
+++ b/Mammoth/Include/Painters.h
@@ -181,7 +181,7 @@ class CItemPainter
 		static void FormatDisplayAttributes (const CVisualPalette &VI, TArray<SDisplayAttribute> &Attribs, const RECT &rcRect, CCartoucheBlock &retBlock, int *retcyHeight = NULL);
 		static void FormatLaunchers (const CVisualPalette &VI, const CMissileItem &MissileItem, const TArray<CItem> &Launchers, const RECT &rcRect, CIconLabelBlock &retLaunchers);
 		static void PaintItemEnhancement (const CVisualPalette &VI, CG32bitImage &Dest, CSpaceObject *pSource, const CItem &Item, const CItemEnhancement &Enhancement, const RECT &rcRect, CG32bitPixel rgbText, DWORD dwOptions, int *retcyHeight = NULL);
-		static void PaintReferenceDamageAdj (const CVisualPalette &VI, CG32bitImage &Dest, int x, int y, int iLevel, int iHP, const int *iDamageAdj, CG32bitPixel rgbText, DWORD dwOptions, const CDamageAdjDesc *pDamageAdjCurve = NULL);
+		static void PaintReferenceDamageAdj (const CVisualPalette &VI, CG32bitImage &Dest, int x, int y, int iLevel, int iHP, const int *iDamageAdj, CG32bitPixel rgbAdvantage, CG32bitPixel rgbDisadvantage, DWORD dwOptions, const CDamageAdjDesc *pDamageAdjCurve = NULL);
 		static void PaintReferenceDamageType (const CVisualPalette &VI, CG32bitImage &Dest, int x, int y, int iDamageType, const CString &sRef, CG32bitPixel rgbText, DWORD dwOptions);
 
 		const CVisualPalette &m_VI;


### PR DESCRIPTION
feat: 104504: collapse identical damage modifiers to tidy up display add more display options for damageAdj on armor/shields

fix: 104505: edge case where 0% damageAdj modifiers could be displayed (ex, monopole deflector)