### PR TITLE
fix: 104490: manually define outlawSpace so that regions (ex, Frontie…

### DIFF
--- a/Transcendence/TransCore/Outlaws.xml
+++ b/Transcendence/TransCore/Outlaws.xml
@@ -13,7 +13,11 @@
 			displayOn="&smHumanSpace;"
 			>
 		<TopologyProcessor priority="secondaryColony">
-			<System criteria="+humanSpace;"	attributes="outlawSpace"/>
+			<System criteria="+newBeyond;"	attributes="outlawSpace"/>
+			<System criteria="+nodeID:SK;"	attributes="outlawSpace"/>
+			<System criteria="+ungoverned;"	attributes="outlawSpace"/>
+			<System criteria="+outerRealm;"	attributes="outlawSpace"/>
+			<System criteria="+nearStars;"	attributes="outlawSpace"/>
 		</TopologyProcessor>
 	</SystemMap>
 


### PR DESCRIPTION
…r) with custom outlaws dont have normal outlaws spawning in them