### PR TITLE
Fix/94789 gaian controller duplication

### DIFF
--- a/Mammoth/Include/TSEDeviceClassesImpl.h
+++ b/Mammoth/Include/TSEDeviceClassesImpl.h
@@ -139,6 +139,7 @@ class CCyberDeckClass : public CDeviceClass
 											 const CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
+											 CItemType **retpAmmoType = NULL,
 											 CItemType **retpType = NULL,
 											 bool bUseCustomAmmoCountHandler = false) override;
 		virtual DWORD GetTargetTypes (const CDeviceItem &DeviceItem) const override { return CTargetList::SELECT_ATTACKERS | CTargetList::SELECT_FORTIFICATION; }

--- a/Mammoth/Include/TSEDevices.h
+++ b/Mammoth/Include/TSEDevices.h
@@ -366,8 +366,9 @@ class CDeviceClass
 											 const CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
+											 CItemType **retpAmmoType = NULL,
 											 CItemType **retpType = NULL,
-											 bool bUseCustomAmmoCountHandler = false) { if (retsLabel) *retsLabel = NULL_STR; if (retiAmmoLeft) *retiAmmoLeft = -1; if (retpType) *retpType = NULL; }
+											 bool bUseCustomAmmoCountHandler = false) { if (retsLabel) *retsLabel = NULL_STR; if (retiAmmoLeft) *retiAmmoLeft = -1; if (retpType) *retpType = NULL; if (retpAmmoType) *retpAmmoType = NULL; }
 		virtual Metric GetShotSpeed (CItemCtx &Ctx) const { return 0.0; }
 		virtual void GetStatus (const CInstalledDevice *pDevice, const CSpaceObject *pSource, int *retiStatus, int *retiMaxStatus) { *retiStatus = 0; *retiMaxStatus = 0; }
 		virtual DWORD GetTargetTypes (const CDeviceItem &DeviceItem) const { return 0; }
@@ -708,8 +709,9 @@ class CInstalledDevice
 		void GetSelectedVariantInfo (const CSpaceObject *pSource, 
 											CString *retsLabel,
 											int *retiAmmoLeft,
+											CItemType **retpAmmoType = NULL,
 											CItemType **retpType = NULL) const
-			{ m_pClass->GetSelectedVariantInfo(pSource, this, retsLabel, retiAmmoLeft, retpType); }
+			{ m_pClass->GetSelectedVariantInfo(pSource, this, retsLabel, retiAmmoLeft, retpAmmoType, retpType); }
 		Metric GetShotSpeed (CItemCtx &Ctx) const { return m_pClass->GetShotSpeed(Ctx); }
 		CSpaceObject *GetSource (void) const { return m_pSource; }
 		CSpaceObject &GetSourceOrThrow (void) const { if (m_pSource) return *m_pSource; else throw CException(ERR_FAIL); }

--- a/Mammoth/Include/TSEWeaponClassImpl.h
+++ b/Mammoth/Include/TSEWeaponClassImpl.h
@@ -159,6 +159,7 @@ class CWeaponClass : public CDeviceClass
 											 const CInstalledDevice *pDevice,
 											 CString *retsLabel,
 											 int *retiAmmoLeft,
+											 CItemType **retpAmmoType = NULL,
 											 CItemType **retpType = NULL,
 											 bool bUseCustomAmmoCountHandler = false) override;
 		virtual Metric GetShotSpeed (CItemCtx &Ctx) const override;

--- a/Mammoth/TSE/CAIBehaviorCtx.cpp
+++ b/Mammoth/TSE/CAIBehaviorCtx.cpp
@@ -829,11 +829,16 @@ int CAIBehaviorCtx::CalcWeaponScore (CShip *pShip, CSpaceObject *pTarget, CInsta
 	//	or the ammo)
 
 	CItemType *pType;
+	CItemType *pAmmoType;
 	pWeapon->GetClass()->GetSelectedVariantInfo(pShip,
 			pWeapon,
 			NULL,
 			NULL,
+			&pAmmoType,
 			&pType);
+
+	if (pAmmoType)
+		pType = pAmmoType;
 
 	//	Base score is based on the level of the variant
 

--- a/Mammoth/TSE/CCExtensions.cpp
+++ b/Mammoth/TSE/CCExtensions.cpp
@@ -7397,29 +7397,27 @@ ICCItem *fnObjGet (CEvalContext *pEvalCtx, ICCItem *pArgs, DWORD dwData)
 					if (pLauncher)
 						{
 						CItemType *pType;
-						pLauncher->GetSelectedVariantInfo(pShip, NULL, NULL, &pType);
-						if (pType)
+						CItemType *pAmmoType;
+						pLauncher->GetSelectedVariantInfo(pShip, NULL, NULL, &pAmmoType, &pType);
+						if (pAmmoType)
 							{
-							if (pType->IsMissile())
+							CItemListManipulator ItemList(pShip->GetItemList());
+							CItem theItem(pAmmoType, 1);
+							if (ItemList.SetCursorAtItem(theItem))
 								{
-								CItemListManipulator ItemList(pShip->GetItemList());
-								CItem theItem(pType, 1);
-								if (ItemList.SetCursorAtItem(theItem))
-									{
-									ICCItem *pItem = CreateListFromItem(theItem);
-									pList->Append(pItem);
-									pItem->Discard();
-									}
+								ICCItem *pItem = CreateListFromItem(theItem);
+								pList->Append(pItem);
+								pItem->Discard();
 								}
-							else
+							}
+						else if (pType)
+							{
+							CItem theItem = pShip->GetNamedDeviceItem(devMissileWeapon);
+							if (theItem.GetType())
 								{
-								CItem theItem = pShip->GetNamedDeviceItem(devMissileWeapon);
-								if (theItem.GetType())
-									{
-									ICCItem *pItem = CreateListFromItem(theItem);
-									pList->Append(CreateListFromItem(theItem));
-									pItem->Discard();
-									}
+								ICCItem *pItem = CreateListFromItem(theItem);
+								pList->Append(CreateListFromItem(theItem));
+								pItem->Discard();
 								}
 							}
 						}

--- a/Mammoth/TSE/CCyberDeckClass.cpp
+++ b/Mammoth/TSE/CCyberDeckClass.cpp
@@ -150,6 +150,7 @@ void CCyberDeckClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 											  const CInstalledDevice *pDevice,
 											  CString *retsLabel,
 											  int *retiAmmoLeft,
+											  CItemType **retpAmmoType,
 											  CItemType **retpType,
 											  bool bUseCustomAmmoCountHandler)
 
@@ -163,6 +164,9 @@ void CCyberDeckClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 
 	if (retiAmmoLeft)
 		*retiAmmoLeft = -1;
+
+	if (retpAmmoType)
+		*retpAmmoType = NULL;
 
 	if (retpType)
 		*retpType = GetItemType();

--- a/Mammoth/TSE/CGaianProcessor.cpp
+++ b/Mammoth/TSE/CGaianProcessor.cpp
@@ -217,7 +217,7 @@ void CGaianProcessorAI::CalcDevices (void)
 				if (m_dwAmmo == 0)
 					{
 					CItemType *pAmmoType = NULL;
-					Weapon.GetSelectedVariantInfo(m_pShip, NULL, NULL, NULL, &pAmmoType);
+					Weapon.GetSelectedVariantInfo(m_pShip, NULL, NULL, &pAmmoType);
 					if (pAmmoType)
 						m_dwAmmo = pAmmoType->GetUNID();
 					}

--- a/Mammoth/TSE/CGaianProcessor.cpp
+++ b/Mammoth/TSE/CGaianProcessor.cpp
@@ -217,7 +217,7 @@ void CGaianProcessorAI::CalcDevices (void)
 				if (m_dwAmmo == 0)
 					{
 					CItemType *pAmmoType = NULL;
-					Weapon.GetSelectedVariantInfo(m_pShip, NULL, NULL, &pAmmoType);
+					Weapon.GetSelectedVariantInfo(m_pShip, NULL, NULL, NULL, &pAmmoType);
 					if (pAmmoType)
 						m_dwAmmo = pAmmoType->GetUNID();
 					}

--- a/Mammoth/TSE/CShip.cpp
+++ b/Mammoth/TSE/CShip.cpp
@@ -2492,7 +2492,7 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons (CInstalledDevice *pDevice)
 							//  If it is an ammo weapon, but does not require items, then it is a charges weapon. Add its ammo to the count.
 							{
 							int iAmmoLeft = 0;
-							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, NULL, true);
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, NULL, NULL, true);
 							iAmmoCount += iAmmoLeft;
 							}
 
@@ -2503,7 +2503,7 @@ int CShip::GetAmmoForSelectedLinkedFireWeapons (CInstalledDevice *pDevice)
 							bool ammoIsAdded = false;
 							int iAmmoLeft = 0;
 							CItemType *pAmmoType;
-							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, &pAmmoType, true);
+							pCurrDeviceClass->GetSelectedVariantInfo(this, &currDevice, NULL, &iAmmoLeft, NULL, &pAmmoType, true);
 							AmmoItemTypes.Find(pAmmoType, &ammoIsAdded);
 							if (!ammoIsAdded)
 								{

--- a/Mammoth/TSE/CWeaponClass.cpp
+++ b/Mammoth/TSE/CWeaponClass.cpp
@@ -3912,6 +3912,7 @@ void CWeaponClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 										   const CInstalledDevice *pDevice,
 										   CString *retsLabel,
 										   int *retiAmmoLeft,
+										   CItemType **retpAmmoType,
 										   CItemType **retpType,
 										   bool bUseCustomAmmoCountHandler)
 
@@ -3933,6 +3934,8 @@ void CWeaponClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 			*retiAmmoLeft = 0;
 		if (retpType)
 			*retpType = NULL;
+		if (retpAmmoType)
+			*retpAmmoType = NULL;
 		}
 
 	//  If we use ammo, return that
@@ -3994,7 +3997,10 @@ void CWeaponClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 			}
 
 		if (retpType)
-			*retpType = pShot->GetAmmoType();
+			*retpType = GetItemType();
+
+		if (retpAmmoType)
+			*retpAmmoType = pShot->GetAmmoType();
 		}
 
 	//	Else if we use charges, return that
@@ -4011,6 +4017,9 @@ void CWeaponClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 			else
 				*retiAmmoLeft = pDevice->GetCharges(pSource);
 			}
+
+		if (retpAmmoType)
+			*retpAmmoType = NULL;
 
 		if (retpType)
 			*retpType = GetItemType();
@@ -4030,6 +4039,9 @@ void CWeaponClass::GetSelectedVariantInfo (const CSpaceObject *pSource,
 			else
 				*retiAmmoLeft = -1;
 			}
+
+		if (retpAmmoType)
+			*retpAmmoType = NULL;
 
 		if (retpType)
 			*retpType = GetItemType();

--- a/Mammoth/TSE/ShipProperties.cpp
+++ b/Mammoth/TSE/ShipProperties.cpp
@@ -466,14 +466,15 @@ ICCItem *CShip::GetPropertyCompatible (CCodeChainCtx &Ctx, const CString &sName)
 			return CC.CreateNil();
 
 		CItemType *pType;
-		pLauncher->GetSelectedVariantInfo(this, NULL, NULL, &pType);
+		CItemType *pAmmoType;
+		pLauncher->GetSelectedVariantInfo(this, NULL, NULL, &pAmmoType, &pType);
 		if (pType == NULL)
 			return CC.CreateNil();
 
-		if (pType->IsMissile())
+		if (pAmmoType)
 			{
 			CItemListManipulator ItemList(const_cast<CShip *>(this)->GetItemList());
-			CItem theItem(pType, 1);
+			CItem theItem(pAmmoType, 1);
 			if (!ItemList.SetCursorAtItem(theItem))
 				return CC.CreateNil();
 

--- a/Mammoth/TSUI/CWeaponHUDCircular.cpp
+++ b/Mammoth/TSUI/CWeaponHUDCircular.cpp
@@ -285,7 +285,7 @@ void CWeaponHUDCircular::PaintWeaponStatus (CShip *pShip, CInstalledDevice *pDev
 
 	CString sVariant;
 	int iAmmoLeft;
-	pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, true);
+	pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, NULL, true);
 	int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
 	if (iSelectedFireAmmoLeft >= 0)
 		iAmmoLeft = iSelectedFireAmmoLeft;

--- a/Mammoth/TSUI/CWeaponHUDDefault.cpp
+++ b/Mammoth/TSUI/CWeaponHUDDefault.cpp
@@ -156,7 +156,7 @@ void CWeaponHUDDefault::PaintDeviceStatus (CShip *pShip, DeviceNames iDev, int x
 
 		CString sVariant;
 		int iAmmoLeft;
-		pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, true);
+		pClass->GetSelectedVariantInfo(pShip, pDevice, &sVariant, &iAmmoLeft, NULL, NULL, true);
 		int iSelectedFireAmmoLeft = pShip->GetAmmoForSelectedLinkedFireWeapons(pDevice);
 		if (iSelectedFireAmmoLeft >= 0)
 			iAmmoLeft = iSelectedFireAmmoLeft;


### PR DESCRIPTION
Actual source of the bug was a poor design practice of inconsistently using a return value for either a device or ammo depending on what was installed.

Function in question was refactored to use two separate return pointers instead.