### PR TITLE
fix: 104562: fix OR criteria for items and everything using ParseCrit…

### DIFF
--- a/Mammoth/TSE/CItemCriteria.cpp
+++ b/Mammoth/TSE/CItemCriteria.cpp
@@ -690,7 +690,7 @@ void CItemCriteria::ParseSubExpression (const char *pPos, DWORD dwFlags)
 					//	Get the modifier
 
 					const char *pStart = pPos;
-					while (*pPos != '\0' && *pPos != ';' && *pPos != ' ' && *pPos != '\t')
+					while (*pPos != '\0' && *pPos != ';' && *pPos != ' ' && *pPos != '\t' && *pPos != '|')
 						{
 						if (*pPos == ':')
 							bSpecialAttrib = true;
@@ -719,6 +719,12 @@ void CItemCriteria::ParseSubExpression (const char *pPos, DWORD dwFlags)
 					//	No trailing semi
 
 					if (*pPos == '\0')
+						pPos--;
+
+					//	Decrement pPos so that we are at the right spot
+					//	to handle the OR criteria
+
+					if (*pPos == '|')
 						pPos--;
 
 					break;

--- a/Mammoth/TSE/Utilities.cpp
+++ b/Mammoth/TSE/Utilities.cpp
@@ -2152,7 +2152,7 @@ CString ParseCriteriaParam (const char **ioPos, bool bExpectColon, bool *retbBin
 	bool bBinaryParam = false;
 	bool bAllowSpaces = false;
 	const char *pStart = pPos;
-	while (*pPos != ';' && (bAllowSpaces || *pPos != ' ') && *pPos != '\t' && *pPos != '\0')
+	while (*pPos != ';' && (bAllowSpaces || *pPos != ' ') && *pPos != '\t' && *pPos != '\0' && *pPos != '|')
 		{
 		if (*pPos == ':')
 			{
@@ -2165,7 +2165,7 @@ CString ParseCriteriaParam (const char **ioPos, bool bExpectColon, bool *retbBin
 	//	If we hit the end, we backup one character because our caller
 	//	will advance the position by one
 
-	*ioPos = (*pPos == '\0' ? (pPos - 1) : pPos);
+	*ioPos = (*pPos == '\0' || *pPos == '|' ? (pPos - 1) : pPos);
 
 	//	Done
 


### PR DESCRIPTION
…eriaParam to function consistently with CAffinityCriteria, where '|' counts as an end-of-criteria delimiter so that it can be put right after a named attribute