### PR TITLE
chore: 104555: add bitwise operators for ints in tlisp

### DIFF
--- a/Alchemy/CodeChain/DefPrimitives.h
+++ b/Alchemy/CodeChain/DefPrimitives.h
@@ -530,6 +530,39 @@ static PRIMITIVEPROCDEF g_DefPrimitives[] =
 
 		"Arguments are the same as (eval expr). Resolution may vary by system.",
 		"v",	PPFLAG_SIDEEFFECTS, },
+
+		{   "bAnd", fnBitwise, FN_BITWISE_AND,
+			"(bAnd x1 [x2 ... xn]) -> bitwise AND (int32)",
+			"v*", 0, },
+
+		{   "bOr",  fnBitwise, FN_BITWISE_OR,
+			"(bOr x1 [x2 ... xn]) -> bitwise OR (int32)",
+			"v*", 0, },
+
+		{   "bXor", fnBitwise, FN_BITWISE_XOR,
+			"(bXor x1 [x2 ... xn]) -> bitwise XOR (int32)",
+			"v*", 0, },
+
+		{   "bNot", fnBitwise, FN_BITWISE_NOT,
+			"(bNot x) -> bitwise NOT (int32)",
+			"v", 0, },
+
+		{   "bShL",  fnBitwise, FN_BITWISE_SHL,
+			"(bShL x count) -> logical left shift (int32)",
+			"vv", 0, },
+
+		{   "bShR",  fnBitwise, FN_BITWISE_SHR,
+			"(bShR x count) -> logical right shift (int32)",
+			"vv", 0, },
+
+		{   "bRoL",  fnBitwise, FN_BITWISE_ROL,
+			"(bRoL x count) -> rotate left 32-bit (int32)",
+			"vv", 0, },
+
+		{   "bRoR",  fnBitwise, FN_BITWISE_ROR,
+			"(bRoR x count) -> rotate right 32-bit (int32)",
+			"vv", 0, },
+
 	};
 
 #define DEFPRIMITIVES_COUNT		(sizeof(g_DefPrimitives) / sizeof(g_DefPrimitives[0]))

--- a/Alchemy/CodeChain/Functions.h
+++ b/Alchemy/CodeChain/Functions.h
@@ -109,6 +109,14 @@
 #define FN_MATH_GAMMA_SCALE_NUMERALS	105
 #define FN_DEBUG_APPLY_TIMED			106
 #define FN_DEBUG_EVAL_TIMED				107
+#define FN_BITWISE_AND                  108
+#define FN_BITWISE_OR                   109
+#define FN_BITWISE_XOR                  110
+#define FN_BITWISE_NOT                  111
+#define FN_BITWISE_SHL                  112
+#define FN_BITWISE_SHR                  113
+#define FN_BITWISE_ROL                  114
+#define FN_BITWISE_ROR                  115
 
 ICCItem *fnAppend (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnApply (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
@@ -168,3 +176,4 @@ ICCItem *fnVecCreateOld (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnVector (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnVecMath (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
 ICCItem *fnVecIndex (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);
+ICCItem *fnBitwise (CEvalContext *pCtx, ICCItem *pArguments, DWORD dwData);


### PR DESCRIPTION
Added bitwise operators for ints.

Test:
<img width="218" height="351" alt="image" src="https://github.com/user-attachments/assets/7fbd9313-e7cf-43d6-b945-cc258c82f1b1" />
