### PR TITLE
Further hit detection optimisation

### DIFF
--- a/Mammoth/TSE/CAIBehaviorCtx.cpp
+++ b/Mammoth/TSE/CAIBehaviorCtx.cpp
@@ -101,6 +101,12 @@ void CAIBehaviorCtx::CalcAvoidPotential (CShip *pShip, CSpaceObject *pTarget)
 
 					if (m_iBarrierClock != -1)
 						{
+
+						//	Prepare for point in object calculations
+
+						SPointInObjectCtx PiOCtx;
+						pObj->PointInObjectInit(PiOCtx);
+
 						int iRange;
 						int iAngle;
 						for (iRange = 1; iRange < 8; iRange++)
@@ -111,7 +117,7 @@ void CAIBehaviorCtx::CalcAvoidPotential (CShip *pShip, CSpaceObject *pTarget)
 							for (iAngle = 0; iAngle < 360; iAngle += 30)
 								{
 								CVector vTest = PolarToVector(iAngle, 1.0);
-								if (pObj->PointInObject(pObj->GetPos(), pShip->GetPos() + (rRange * vTest)))
+								if (pObj->PointInObject(PiOCtx, pObj->GetPos(), pShip->GetPos() + (rRange * vTest)))
 									{
 									m_vPotential = m_vPotential - (rStrength * vTest);
 									m_fHasAvoidPotential = true;

--- a/Mammoth/TSE/CContinuousBeam.cpp
+++ b/Mammoth/TSE/CContinuousBeam.cpp
@@ -349,13 +349,18 @@ bool CContinuousBeam::HitTestSegment (SSegment &Segment, CVector *retvHitPos)
 						|| pObj == this)
 					continue;
 
+				//	Prepare for point in object calculations
+
+				SPointInObjectCtx PiOCtx;
+				pObj->PointInObjectInit(PiOCtx);
+
 				//	See where we hit this object (if at all)
 
 				Metric rTest = 0.0;
 				CVector vTest = vCurrPos;
 				while (rTest < rLength)
 					{
-					if (pObj->PointInObject(pObj->GetPos(), vTest))
+					if (pObj->PointInObject(PiOCtx, pObj->GetPos(), vTest))
 						{
 						Hits.Insert(rTest, CHitCtx(pObj, vTest, iHitDir));
 						break;
@@ -424,13 +429,18 @@ bool CContinuousBeam::HitTestSegment (SSegment &Segment, CVector *retvHitPos)
 						|| pObj == this)
 					continue;
 
+				//	Prepare for point in object calculations
+
+				SPointInObjectCtx PiOCtx;
+				pObj->PointInObjectInit(PiOCtx);
+
 				//	See where we hit this object (if at all)
 
 				Metric rTest = 0.0;
 				CVector vTest = vCurrPos;
 				while (rTest < rBestDist)
 					{
-					if (pObj->PointInObject(pObj->GetPos(), vTest))
+					if (pObj->PointInObject(PiOCtx, pObj->GetPos(), vTest))
 						{
 						pHit = pObj;
 						vBestHit = vTest;

--- a/Mammoth/TSE/CParticleArray.cpp
+++ b/Mammoth/TSE/CParticleArray.cpp
@@ -1824,20 +1824,22 @@ void CParticleArray::UpdateCollisions (const CParticleSystemDesc &Desc, SEffectU
 	CVector vLL;
 	GetBounds(&vUR, &vLL);
 
-	//	Loop over all objects in the system
+	const CSpaceObjectGrid &Grid = Ctx.pSystem->GetObjectGrid();
+	SSpaceObjectGridEnumerator i;
+	Grid.EnumStart(i, vUR, vLL, 0);
 
-	for (int i = 0; i < Ctx.pSystem->GetObjectCount(); i++)
+	//	Loop over all objects in the grid box
+
+	while (Grid.EnumHasMore(i))
 		{
-		CSpaceObject *pObj = Ctx.pSystem->GetObject(i);
+		CSpaceObject *pObj = Grid.EnumGetNext(i);
 
 		//	If the object is in the bounding box then remember
 		//	it so that we can do a more accurate calculation.
 
 		if (pObj 
-				&& pObj->InBox(vUR, vLL)
 				&& Ctx.pObj->CanHit(pObj) 
 				&& pObj->CanBeHit() 
-				&& !pObj->IsDestroyed()
 				&& pObj != Ctx.pObj)
 			{
 

--- a/Mammoth/TSE/CRadiusDamage.cpp
+++ b/Mammoth/TSE/CRadiusDamage.cpp
@@ -139,13 +139,18 @@ void CRadiusDamage::DamageAll (SUpdateCtx &Ctx)
 		CVector vDist = (pObj->GetPos() - GetPos());
 		int iAngle = VectorToPolar(vDist);
 
+		//	Prepare for point in object calculations
+
+		SPointInObjectCtx PiOCtx;
+		pObj->PointInObjectInit(PiOCtx);
+
 		//	Figure out where we hit this object
 
 		Metric rObjRadius = 0.5 * pObj->GetHitSize();
 		CVector vHitPos = pObj->GetPos() - PolarToVector(iAngle, rObjRadius);
 		CVector vInc = PolarToVector(iAngle, 2.0 * g_KlicksPerPixel);
 		int iMax = mathRound(2.0 * rObjRadius / (2.0 * g_KlicksPerPixel));
-		while (!pObj->PointInObject(pObj->GetPos(), vHitPos) && iMax-- > 0)
+		while (!pObj->PointInObject(PiOCtx, pObj->GetPos(), vHitPos) && iMax-- > 0)
 			vHitPos = vHitPos + vInc;
 
 		//	The hit position is what we use to figure out damage

--- a/Mammoth/TSE/CShockwaveHitTest.cpp
+++ b/Mammoth/TSE/CShockwaveHitTest.cpp
@@ -236,6 +236,11 @@ void CShockwaveHitTest::Update (SEffectUpdateCtx &Ctx, const CVector &vPos, Metr
 			int iHitCount = 0;
 			utlMemSet(&SegHit[0], sizeof(SHitData) * SegHit.GetCount(), 0);
 
+			//	Prepare for point in object calculations
+
+			SPointInObjectCtx PiOCtx;
+			pObj->PointInObjectInit(PiOCtx);
+
 			//	Loop through the grid to see if we hit anything
 
 			Metric rTestRadius = rStartRadius;
@@ -272,7 +277,7 @@ void CShockwaveHitTest::Update (SEffectUpdateCtx &Ctx, const CVector &vPos, Metr
 							&& m_Segments[iSegment].dwLastHitID != pObj->GetID())
 						{
 						CVector vHitTest = vPos + PolarToVector((int)(rTheAngle + rRandomOffset), rTestRadius);
-						if (pObj->PointInObject(pObj->GetPos(), vHitTest))
+						if (pObj->PointInObject(PiOCtx, pObj->GetPos(), vHitTest))
 							{
 							SegHit[iSegment].bHit = true;
 							SegHit[iSegment].iAngle = (int)rTheAngle;

--- a/Mammoth/TSE/CSpaceObject.cpp
+++ b/Mammoth/TSE/CSpaceObject.cpp
@@ -6548,10 +6548,7 @@ bool CSpaceObject::IsLineOfFireClear (const CInstalledDevice *pWeapon,
 
 				if (rDistFromTarget2 < BOUNDS_CHECK_DIST2)
 					{
-					CVector vUR, vLL;
-					pObj->GetBoundingRect(&vUR, &vLL);
-
-					if (rDistFromTarget2 < 2.0 * vUR.Length2()
+					if (pObj->PointInBounds(vTarget)
 							&& pObj->PointInObject(pObj->GetPos(), vTarget))
 						{
 						if (retpFriend) *retpFriend = pObj;


### PR DESCRIPTION
See [Hexacoral shockwave can cause slow down](https://ministry.kronosaur.com/record.hexm?id=104481)

I was still seeing significant slowdowns with shockwave hit detection even after #189 was merged (i.e. update times 20-40 ms). After running some tests it looks like the hit detection code was spending almost all it's time trying to find the station images (not ships) and not on the actual collision detection.
i.e `CStation::PointInObject` -> `GetImage` -> `CCompositeImageDesc::GetImage` -> `FindCacheEntry` (and the == operator)

It appears that some of the hit detection code is optimised to avoid repeated `GetImage` calls by using `SPointInObjectCtx`, so I've added this optimisation to:
* `CAIBehaviorCtx::CalcAvoidPotential`
* `CContinuousBeam::HitTestSegment`
* `CRadiusDamage::DamageAll`
* `CShockwaveHitTest::Update`

Also:
* updates `CParticleArray::UpdateCollisions` to use the space object grid for the coarse pass.
* `CSpaceObject::IsLineOfFireClear` was comparing a distance to an absolute position. I'm guessing it was supposed to be a coarse distance check, so I've replaced it with a PointInBounds check.

Note - it looks like most of the collision detection functions do not do coarse checks using PointInBounds or similar, but rely on the bounds check in the image code (`PointInImage`). If necessary we could and some more PointInBounds checks to avoid the GetImage overhead.