### PR TITLE
fix: 106544: fix edgecase where lowest hp number was always rotated b…

### DIFF
--- a/Alchemy/Include/Euclid.h
+++ b/Alchemy/Include/Euclid.h
@@ -15,6 +15,9 @@ constexpr Metric PI = 3.14159265358979;
 constexpr Metric HALF_PI = 0.5 * PI;
 constexpr Metric TAU = 2.0 * PI;
 
+constexpr Metric RAD_EPSILON = 0.0000001;
+constexpr Metric DEG_EPSILON = RAD_EPSILON * 180.0 / PI;
+
 const Metric SQRT_3 = sqrt(3.0);
 
 constexpr Metric DBL_INFINITY = 1.7976931348623158e+308;	//	DBL_MAX
@@ -61,9 +64,13 @@ inline int AngleMiddle (int iLowAngle, int iHighAngle)
 inline int AngleToDegrees (Metric rAngle) { return AngleMod(mathRound(rAngle * 180.0 / PI)); }
 
 inline Metric mathAngleMod (double rAngle) { if (rAngle >= 0.0) return fmod(rAngle, TAU); else return TAU - fmod(-rAngle, TAU); }
+inline Metric mathAngleMod180 (double rAngle) { return mathAngleMod(rAngle + PI) - PI; }
 inline Metric mathAngleModDegrees (double rAngle) { if (rAngle >= 0.0) return fmod(rAngle, 360.0); else return 360.0 - fmod(-rAngle, 360.0); }
+inline Metric mathAngleMod180Degrees (double rAngle) { return mathAngleModDegrees(rAngle + 180.0) - 180.0; }
 inline Metric mathAngleBearing (Metric rAngle, Metric rOrigin) { Metric rDiff = mathAngleMod(rAngle - rOrigin); return (rDiff > PI ? rDiff - TAU : rDiff); }
 inline Metric mathAngleDiff (double rFrom, double rTo) { return mathAngleMod(rTo - rFrom); }
+inline Metric mathAngleIsZero (double rAngle) { return abs(mathAngleMod180(rAngle)) < RAD_EPSILON; }
+inline Metric mathAngleIsZeroDegrees (double rAngle) { return abs(mathAngleMod180Degrees(rAngle)) < DEG_EPSILON; }
 inline constexpr Metric mathDegreesToRadians (int iAngle) { return iAngle * PI / 180.0; }
 inline constexpr Metric mathDegreesToRadians (Metric rDegrees) { return PI * rDegrees / 180.0; }
 inline constexpr Metric mathInterpolate (Metric rFrom, Metric rTo, Metric rInterpolate) { return rFrom + (rInterpolate * (rTo - rFrom)); }

--- a/Mammoth/TSUI/CArmorHUDRingSegments.cpp
+++ b/Mammoth/TSUI/CArmorHUDRingSegments.cpp
@@ -190,7 +190,6 @@ void CArmorHUDRingSegments::DrawIntegrityBox (CG32bitImage &Dest, const SSegment
 //	DrawIntegrityBoxText
 //
 //	Draws the armor integrity value on an arc background.
-//	Note: Seg.rHPTextRotation should be within -pi/2 to +pi/2
 //
 void CArmorHUDRingSegments::DrawIntegrityBoxText (CG32bitImage &Dest, const SSegment &Seg, CG32bitPixel rgbColor) const
 
@@ -205,7 +204,7 @@ void CArmorHUDRingSegments::DrawIntegrityBoxText (CG32bitImage &Dest, const SSeg
 	CVector vCenter(m_xCenter, m_yCenter);
 	CVector vText = vCenter + Seg.vHPText;
 
-	if (abs(Seg.rHPTextRotation) < g_Epsilon)
+	if (mathAngleIsZero(Seg.rHPTextRotation))
 		MediumFont.DrawText(Dest, (int)vText.GetX(), (int)vText.GetY(), rgbColor, Seg.sHP, CG16bitFont::AlignCenter);
 	else
 		CGDraw::Text(Dest,

--- a/Mammoth/TSUI/CArmorHUDRingSegments.cpp
+++ b/Mammoth/TSUI/CArmorHUDRingSegments.cpp
@@ -36,13 +36,15 @@ ALERROR CArmorHUDRingSegments::Bind (SDesignLoadCtx &Ctx)
 	return NOERROR;
 	}
 
-void CArmorHUDRingSegments::CalcHPLabelBox (int iAngle, int iRadius, SSegment &Seg)
-
 //	CalcHPLabelBox
 //
 //	Compose the position of the HP label.
+//	iAngle 0 is to the right
+//
+void CArmorHUDRingSegments::CalcHPLabelBox (int iAngle, int iRadius, SSegment &Seg)
 
 	{
+	iAngle = AngleMod(iAngle);
 	Metric rCenterAngle = ::mathDegreesToRadians(iAngle);
 
 	//	Figure out if we're drawing the text radially or along the arc.
@@ -106,7 +108,7 @@ void CArmorHUDRingSegments::CalcHPLabelBox (int iAngle, int iRadius, SSegment &S
 			{
 			int iTextRadius = Seg.iArcRadius + ((Seg.iArcWidth - m_cyMaxValue) / 2) - 1;
 			Seg.vHPText = CVector::FromPolarInv(rCenterAngle, iTextRadius);
-			Seg.rHPTextRotation = rCenterAngle + (HALF_PI);
+			Seg.rHPTextRotation = rCenterAngle - (HALF_PI * 3);
 			}
 		}
 	}
@@ -185,11 +187,12 @@ void CArmorHUDRingSegments::DrawIntegrityBox (CG32bitImage &Dest, const SSegment
 	DEBUG_CATCH
 	}
 
-void CArmorHUDRingSegments::DrawIntegrityBoxText (CG32bitImage &Dest, const SSegment &Seg, CG32bitPixel rgbColor) const
-
 //	DrawIntegrityBoxText
 //
 //	Draws the armor integrity value on an arc background.
+//	Note: Seg.rHPTextRotation should be within -pi/2 to +pi/2
+//
+void CArmorHUDRingSegments::DrawIntegrityBoxText (CG32bitImage &Dest, const SSegment &Seg, CG32bitPixel rgbColor) const
 
 	{
 	DEBUG_TRY
@@ -202,7 +205,7 @@ void CArmorHUDRingSegments::DrawIntegrityBoxText (CG32bitImage &Dest, const SSeg
 	CVector vCenter(m_xCenter, m_yCenter);
 	CVector vText = vCenter + Seg.vHPText;
 
-	if (Seg.rHPTextRotation == 0.0)
+	if (abs(Seg.rHPTextRotation) < g_Epsilon)
 		MediumFont.DrawText(Dest, (int)vText.GetX(), (int)vText.GetY(), rgbColor, Seg.sHP, CG16bitFont::AlignCenter);
 	else
 		CGDraw::Text(Dest,


### PR DESCRIPTION
…y a pixel due to unbounded radian angles and fp roundoff error (which might also be leading to the heap corruption warnings on painting the wrong pixels?)