### PR TITLE
feat: 106592: add safer string to int parsing functions with 64bit in…

### DIFF
--- a/Alchemy/Include/KernelString.h
+++ b/Alchemy/Include/KernelString.h
@@ -310,12 +310,12 @@ Kernel::CString strToUpper (const Kernel::CString &sString);
 Kernel::CString strToXMLText (const Kernel::CString &sString, bool bInBody = false);
 Kernel::CString strTrimWhitespace (const Kernel::CString &sString, bool bLeading = true, bool bTrailing = true);
 Kernel::CString strWord (const Kernel::CString &sString, int iWordPos);
-int strToInt32(const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
-UINT32 strToUInt32(const Kernel::CString& sString, UINT32 iFailResult, bool* retbFailed = NULL);
-INT64 strToInt64(const Kernel::CString& sString, INT64 iFailResult, bool* retbFailed = NULL);
-UINT64 strToUInt64(const Kernel::CString& sString, UINT64 iFailResult, bool* retbFailed = NULL);
+int strToInt32 (const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
+UINT32 strToUInt32 (const Kernel::CString& sString, UINT32 iFailResult, bool* retbFailed = NULL);
+INT64 strToInt64 (const Kernel::CString& sString, INT64 iFailResult, bool* retbFailed = NULL);
+UINT64 strToUInt64 (const Kernel::CString& sString, UINT64 iFailResult, bool* retbFailed = NULL);
 
 //	DEPRECATED: use strToInt32 or strToUInt32 instead
-int strToInt(const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
+int strToInt (const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
 
 

--- a/Alchemy/Include/KernelString.h
+++ b/Alchemy/Include/KernelString.h
@@ -305,11 +305,17 @@ double strToDouble (const Kernel::CString &sString, double rFailResult, bool *re
 #define UNIT_STR_MASS_TONS							CONSTLIT("t")
 double strMassToDoubleTons (const Kernel::CString &sString, double rFailResult, bool *retbFailed = NULL);
 Kernel::CString strToFilename (const Kernel::CString &sString);
-int strToInt (const Kernel::CString &sString, int iFailResult, bool *retbFailed = NULL);
 Kernel::CString strToLower (const Kernel::CString &sString);
 Kernel::CString strToUpper (const Kernel::CString &sString);
 Kernel::CString strToXMLText (const Kernel::CString &sString, bool bInBody = false);
 Kernel::CString strTrimWhitespace (const Kernel::CString &sString, bool bLeading = true, bool bTrailing = true);
 Kernel::CString strWord (const Kernel::CString &sString, int iWordPos);
+int strToInt32(const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
+UINT32 strToUInt32(const Kernel::CString& sString, UINT32 iFailResult, bool* retbFailed = NULL);
+INT64 strToInt64(const Kernel::CString& sString, INT64 iFailResult, bool* retbFailed = NULL);
+UINT64 strToUInt64(const Kernel::CString& sString, UINT64 iFailResult, bool* retbFailed = NULL);
+
+//	DEPRECATED: use strToInt32 or strToUInt32 instead
+int strToInt(const Kernel::CString& sString, int iFailResult, bool* retbFailed = NULL);
 
 

--- a/Alchemy/Include/KernelString.h
+++ b/Alchemy/Include/KernelString.h
@@ -248,8 +248,32 @@ inline char strLowerCaseAbsolute (char chChar) { if (!Kernel::g_bLowerCaseAbsolu
 bool strNeedsEscapeCodes (const Kernel::CString &sString);
 
 #define PARSE_THOUSAND_SEPARATOR				0x00000001
+#define PARSE_ALLOW_OVERFLOW					0x00000002
 double strParseDouble (const char *pStart, double rNullResult, const char **retpEnd, bool *retbNullValue);
+UINT64 strParseUInt64 (const char* pStart, UINT64 u64NullResult, UINT32 uFlags = 0, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL);
+inline UINT64 strParseUInt64(const char* pStart, UINT64 u64NullResult, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL)
+	{
+	return Kernel::strParseUInt64(pStart, u64NullResult, 0, retpEnd, retbNullValue, retbOverflowed, retbNegativeCharDetected);
+	}
+INT64 strParseInt64 (const char* pStart, INT64 i64NullResult, UINT32 uFlags = 0, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL);
+inline INT64 strParseInt64(const char* pStart, INT64 i64NullResult, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL)
+	{
+	return Kernel::strParseInt64(pStart, i64NullResult, 0, retpEnd, retbNullValue, retbOverflowed, retbNegativeCharDetected);
+	}
+UINT32 strParseUInt32 (const char* pStart, UINT32 uNullResult, UINT32 uFlags = 0, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL);
+inline UINT32 strParseUInt32(const char* pStart, UINT32 uNullResult, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL)
+	{
+	return Kernel::strParseUInt32(pStart, uNullResult, 0, retpEnd, retbNullValue, retbOverflowed, retbNegativeCharDetected);
+	}
+INT32 strParseInt32 (const char* pStart, INT32 iNullResult, UINT32 uFlags = 0, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL);
+inline INT32 strParseInt32(const char* pStart, INT32 iNullResult, const char** retpEnd = NULL, bool* retbNullValue = NULL, bool* retbOverflowed = NULL, bool* retbNegativeCharDetected = NULL)
+	{
+	return Kernel::strParseInt32(pStart, iNullResult, 0, retpEnd, retbNullValue, retbOverflowed, retbNegativeCharDetected);
+	}
+
+//	Deprecated - use strParseInt32/strParseUInt32 instead
 int strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, const char **retpEnd = NULL, bool *retbNullValue = NULL);
+//	Deprecated - use strParseInt32/strParseUInt32 instead
 inline int strParseInt (const char *pStart, int iNullResult, const char **retpEnd = NULL, bool *retbNullValue = NULL) { return Kernel::strParseInt(pStart, iNullResult, 0, retpEnd, retbNullValue); }
 int strParseIntOfBase (const char *pStart, int iBase, int iNullResult, const char **retpEnd = NULL, bool *retbNullValue = NULL);
 

--- a/Alchemy/Include/XMLUtil.h
+++ b/Alchemy/Include/XMLUtil.h
@@ -96,6 +96,10 @@ class CXMLElement
 		bool FindAttributeBool (const CString &sName, bool *retbValue = NULL) const;
 		bool FindAttributeDouble (const CString &sName, double *retrValue = NULL) const;
 		bool FindAttributeInteger (const CString &sName, int *retiValue = NULL) const;
+		bool FindAttributeInt32 (const CString &sName, INT32 *retiValue = NULL) const;
+		bool FindAttributeUInt32 (const CString &sName, UINT32 *retiValue = NULL) const;
+		bool FindAttributeInt64 (const CString &sName, INT64 *retiValue = NULL) const;
+		bool FindAttributeUInt64 (const CString &sName, UINT64 *retiValue = NULL) const;
 		CString GetAttribute (const CString &sName) const;
 		CString GetAttribute (int iIndex) const { return m_Attributes[iIndex]; }
 		bool GetAttributeBool (const CString &sName) const;

--- a/Alchemy/Include/XMLUtil.h
+++ b/Alchemy/Include/XMLUtil.h
@@ -115,7 +115,7 @@ class CXMLElement
 		UINT32 GetAttributeUInt32 (const CString& sName) const { return strToUInt32(GetAttribute(sName), 0, NULL); }
 		UINT32 GetAttributeUInt32Default (const CString& sName, UINT32 uNull) const;
 		UINT32 GetAttributeUInt32Bounded (const CString& sName, UINT32 uMin, UINT32 uMax = 0xFFFF'FFFF, UINT32 iNull = 0) const;
-		bool GetAttributeUInt32Range (const CString &sName, UINT32 *retiLow, UINT32 *retiHigh, UINT32 iMin = 0, UINT32 iMax = 0xFFFF'FFFF'FFFF'FFFF, UINT32 iNullLow = 0, UINT32 iNullHigh = 0, bool bAllowInverted = false) const;
+		bool GetAttributeUInt32Range (const CString &sName, UINT32 *retiLow, UINT32 *retiHigh, UINT32 iMin = 0, UINT32 iMax = 0xFFFF'FFFF, UINT32 iNullLow = 0, UINT32 iNullHigh = 0, bool bAllowInverted = false) const;
 		INT64 GetAttributeInt64 (const CString& sName) const { return strToInt64(GetAttribute(sName), 0, NULL); }
 		INT64 GetAttributeInt64Default (const CString& sName, INT64 iNull) const;
 		INT64 GetAttributeInt64Bounded (const CString& sName, INT64 iMin, INT64 iMax = -1, INT64 iNull = 0) const;
@@ -124,10 +124,10 @@ class CXMLElement
 		UINT64 GetAttributeUInt64Default (const CString& sName, UINT64 uNull) const;
 		UINT64 GetAttributeUInt64Bounded (const CString& sName, UINT64 uMin, UINT64 uMax = 0xFFFF'FFFF'FFFF'FFFF, UINT64 uNull = 0) const;
 		bool GetAttributeUInt64Range (const CString &sName, UINT64 *retiLow, UINT64 *retiHigh, UINT64 iMin = 0, UINT64 iMax = 0xFFFF'FFFF'FFFF'FFFF, UINT64 iNullLow = 0, UINT64 iNullHigh = 0, bool bAllowInverted = false) const;
-		ALERROR GetAttributeIntegerList (const CString &sName, TArray<int> *pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
-		ALERROR GetAttributeIntegerList (const CString &sName, TArray<DWORD> *pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
-		ALERROR GetAttributeIntegerList (const CString& sName, TArray<INT64>* pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
-		ALERROR GetAttributeIntegerList (const CString& sName, TArray<UINT64>* pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
+		ALERROR GetAttributeIntegerList (const CString &sName, TArray<int> *pList) const;
+		ALERROR GetAttributeIntegerList (const CString &sName, TArray<DWORD> *pList) const;
+		ALERROR GetAttributeIntegerList (const CString& sName, TArray<INT64>* pList) const;
+		ALERROR GetAttributeIntegerList (const CString& sName, TArray<UINT64>* pList) const;
 		double GetAttributeFloat (const CString &sName) const;
 		const CString &GetAttributeName (int iIndex) const { return m_Keywords.GetIdentifier(m_Attributes.GetKey(iIndex)); }
 		int GetAttributeTriState (const CString &sName) const;

--- a/Alchemy/Include/XMLUtil.h
+++ b/Alchemy/Include/XMLUtil.h
@@ -103,12 +103,31 @@ class CXMLElement
 		double GetAttributeDouble (const CString &sName) const;
 		double GetAttributeDoubleDefault (const CString &sName, double rNull) const;
 		double GetAttributeDoubleBounded (const CString &sName, double rMin, double rMax = -1.0, double rNull = 0.0) const;
-		int GetAttributeInteger (const CString &sName) const;
+		//	DEPRECATED: use GetAttributeInt32/64 or GetAttributeUInt32/64
+		int GetAttributeInteger (const CString& sName) const { return strToInt(GetAttribute(sName), 0, NULL); }
 		int GetAttributeIntegerDefault (const CString &sName, int iNull) const;
 		int GetAttributeIntegerBounded (const CString &sName, int iMin, int iMax = -1, int iNull = 0) const;
-		bool GetAttributeIntegerRange (const CString &sName, int *retiLow, int *retiHigh, int iMin = 0, int iMax = -1, int iNullLow = 0, int iNullHigh = 0, bool bAllowInverted = false) const;
-		ALERROR GetAttributeIntegerList (const CString &sName, TArray<int> *pList) const;
-		ALERROR GetAttributeIntegerList (const CString &sName, TArray<DWORD> *pList) const;
+		bool GetAttributeIntegerRange(const CString& sName, int* retiLow, int* retiHigh, int iMin = 0, int iMax = -1, int iNullLow = 0, int iNullHigh = 0, bool bAllowInverted = false) const;
+		int GetAttributeInt32 (const CString& sName) const { return strToInt32(GetAttribute(sName), 0, NULL); }
+		int GetAttributeInt32Default (const CString& sName, int iNull) const;
+		int GetAttributeInt32Bounded (const CString& sName, int iMin, int iMax = -1, int iNull = 0) const;
+		bool GetAttributeInt32Range (const CString& sName, int* retiLow, int* retiHigh, int iMin = 0, int iMax = -1, int iNullLow = 0, int iNullHigh = 0, bool bAllowInverted = false) const;
+		UINT32 GetAttributeUInt32 (const CString& sName) const { return strToUInt32(GetAttribute(sName), 0, NULL); }
+		UINT32 GetAttributeUInt32Default (const CString& sName, UINT32 uNull) const;
+		UINT32 GetAttributeUInt32Bounded (const CString& sName, UINT32 uMin, UINT32 uMax = 0xFFFF'FFFF, UINT32 iNull = 0) const;
+		bool GetAttributeUInt32Range (const CString &sName, UINT32 *retiLow, UINT32 *retiHigh, UINT32 iMin = 0, UINT32 iMax = 0xFFFF'FFFF'FFFF'FFFF, UINT32 iNullLow = 0, UINT32 iNullHigh = 0, bool bAllowInverted = false) const;
+		INT64 GetAttributeInt64 (const CString& sName) const { return strToInt64(GetAttribute(sName), 0, NULL); }
+		INT64 GetAttributeInt64Default (const CString& sName, INT64 iNull) const;
+		INT64 GetAttributeInt64Bounded (const CString& sName, INT64 iMin, INT64 iMax = -1, INT64 iNull = 0) const;
+		bool GetAttributeInt64Range (const CString &sName, INT64 *retiLow, INT64 *retiHigh, INT64 iMin = 0, INT64 iMax = -1, INT64 iNullLow = 0, INT64 iNullHigh = 0, bool bAllowInverted = false) const;
+		UINT64 GetAttributeUInt64 (const CString& sName) const { return strToUInt64(GetAttribute(sName), 0, NULL); }
+		UINT64 GetAttributeUInt64Default (const CString& sName, UINT64 uNull) const;
+		UINT64 GetAttributeUInt64Bounded (const CString& sName, UINT64 uMin, UINT64 uMax = 0xFFFF'FFFF'FFFF'FFFF, UINT64 uNull = 0) const;
+		bool GetAttributeUInt64Range (const CString &sName, UINT64 *retiLow, UINT64 *retiHigh, UINT64 iMin = 0, UINT64 iMax = 0xFFFF'FFFF'FFFF'FFFF, UINT64 iNullLow = 0, UINT64 iNullHigh = 0, bool bAllowInverted = false) const;
+		ALERROR GetAttributeIntegerList (const CString &sName, TArray<int> *pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
+		ALERROR GetAttributeIntegerList (const CString &sName, TArray<DWORD> *pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
+		ALERROR GetAttributeIntegerList (const CString& sName, TArray<INT64>* pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
+		ALERROR GetAttributeIntegerList (const CString& sName, TArray<UINT64>* pList) const { return ParseAttributeIntegerList(GetAttribute(sName), pList); }
 		double GetAttributeFloat (const CString &sName) const;
 		const CString &GetAttributeName (int iIndex) const { return m_Keywords.GetIdentifier(m_Attributes.GetKey(iIndex)); }
 		int GetAttributeTriState (const CString &sName) const;
@@ -189,3 +208,5 @@ class CEntityResolverList : public IXMLParserController
 ALERROR CreateXMLElementFromCommandLine (int argc, const char *argv[], CXMLElement **retpElement);
 ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<int> *pList);
 ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<DWORD> *pList);
+ALERROR ParseAttributeIntegerList (const CString& sValue, TArray<INT64>* pList);
+ALERROR ParseAttributeIntegerList (const CString& sValue, TArray<UINT64>* pList);

--- a/Alchemy/Kernel/CString.cpp
+++ b/Alchemy/Kernel/CString.cpp
@@ -2915,8 +2915,6 @@ int Kernel::strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, con
 
 	if (bHex)
 		{
-		DWORD dwInt = 0;
-
 		while (*pPos != '\0' 
 				&& ((*pPos >= '0' && *pPos <= '9') 
 					|| (*pPos >= 'a' && *pPos <='f')

--- a/Alchemy/Kernel/CString.cpp
+++ b/Alchemy/Kernel/CString.cpp
@@ -3484,14 +3484,56 @@ CString Kernel::strToFilename (const CString &sString)
 	return sResult;
 	}
 
-int Kernel::strToInt (const CString &sString, int iFailResult, bool *retbFailed)
-
-//	CStringToInt
+//	strToInt
+// 
+//  Deprecated
 //
 //	Converts a string to an integer
+//
+int Kernel::strToInt (const CString &sString, int iFailResult, bool *retbFailed)
 
 	{
 	return strParseInt(sString.GetASCIIZPointer(), iFailResult, NULL, retbFailed);
+	}
+
+//	strToInt32
+//
+//	Converts a string to an integer
+//
+int Kernel::strToInt32 (const CString &sString, int iFailResult, bool *retbFailed)
+
+	{
+	return strParseInt32(sString.GetASCIIZPointer(), iFailResult, NULL, retbFailed);
+	}
+
+//	strToUInt32
+//
+//	Converts a string to an integer
+//
+UINT32 Kernel::strToUInt32(const CString& sString, UINT32 iFailResult, bool* retbFailed)
+
+	{
+	return strParseUInt32(sString.GetASCIIZPointer(), iFailResult, NULL, retbFailed);
+	}
+
+//	strToInt64
+//
+//	Converts a string to an integer
+//
+INT64 Kernel::strToInt64 (const CString &sString, INT64 iFailResult, bool *retbFailed)
+
+	{
+	return strParseInt64(sString.GetASCIIZPointer(), iFailResult, NULL, retbFailed);
+	}
+
+//	strToUInt64
+//
+//	Converts a string to an integer
+//
+UINT64 Kernel::strToUInt64(const CString& sString, UINT64 iFailResult, bool* retbFailed)
+
+	{
+	return strParseUInt64(sString.GetASCIIZPointer(), iFailResult, NULL, retbFailed);
 	}
 
 CString Kernel::strToLower (const CString &sString)

--- a/Alchemy/Kernel/CString.cpp
+++ b/Alchemy/Kernel/CString.cpp
@@ -2455,34 +2455,416 @@ double Kernel::strParseDouble (const char *pStart, double rNullResult, const cha
 	return atof(szBuffer);
 	}
 
-int Kernel::strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, const char **retpEnd, bool *retbNullValue)
 
-//	strParseInt
+//	strParseUInt64
 //
 //	pStart: Start parsing. Skips any leading whitespace
 //	iNullResult: If there are no valid numbers, returns this value
 //	retpEnd: Returns the character at which we stopped parsing
 //	retbNullValue: Returns TRUE if there are no valid numbers.
+// 	retbNegativeChatDetected: Returns TRUE if a '-' was detected immediately preceding the number.
+// 
+// 	Flags:
+// 	   PARSE_ALLOW_OVERFLOWL: continue shifting bits after exceeding 0xFFFF'FFFF'FFFF'FFFF
+// 	   PARSE_THOUSAND_SEPARATOR: allow
+//
+UINT64 Kernel::strParseUInt64 (
+	const char *pStart,
+	UINT64 u64NullResult,
+	UINT32 uFlags,
+	const char **retpEnd,
+	bool *retbNullValue,
+	bool *retbOverflowed,
+	bool *retbNegativeCharDetected)
 
 	{
-	const char *pPos;
-	BOOL bNegative;
-	BOOL bFoundNumber;
-	BOOL bHex;
-	int iInt;
+	const char *pPos = pStart;
+	BOOL bNegative = false;
+	BOOL bFoundNumber = false;
+	BOOL bHex = false;
+	UINT64 u64Int = 0;
 
-	bool bExpectSeparators = ((dwFlags & PARSE_THOUSAND_SEPARATOR) ? true : false);
+	//	Parse flags
+
+	bool bExpectSeparators = uFlags & PARSE_THOUSAND_SEPARATOR;
+	bool bAllowOverflow = uFlags & PARSE_ALLOW_OVERFLOW;
 
 	//	Preset
 
 	if (retbNullValue)
 		*retbNullValue = false;
+	if (retbOverflowed)
+		*retbOverflowed = false;
+	if (retbNegativeCharDetected)
+		*retbNegativeCharDetected = false;
 
-	pPos = pStart;
-	bNegative = FALSE;
-	bFoundNumber = FALSE;
-	bHex = FALSE;
-	iInt = 0;
+	//	Skip whitespace
+
+	while (*pPos == ' ' || *pPos == '\t' || *pPos == '\n' || *pPos == '\r')
+		pPos++;
+
+	//	If NULL, then we're done
+
+	if (*pPos == '\0')
+		{
+		if (retbNullValue)
+			*retbNullValue = true;
+
+		if (retpEnd)
+			*retpEnd = pPos;
+
+		return u64NullResult;
+		}
+
+	//	If negative, remember it
+
+	if (*pPos == '-')
+		{
+		bNegative = TRUE;
+		pPos++;
+		}
+	else if (*pPos == '+')
+		pPos++;
+
+	//	See if this is a hex number
+
+	if (*pPos == '0')
+		{
+		pPos++;
+		bFoundNumber = TRUE;
+
+		//	If the next character is x (or X) then we've got
+		//	a Hex number
+
+		if (*pPos == 'x' || *pPos == 'X')
+			{
+			pPos++;
+			bHex = TRUE;
+			}
+		}
+
+	//	Keep parsing
+
+	if (bHex)
+		{
+		while (*pPos != '\0' 
+				&& ((*pPos >= '0' && *pPos <= '9') 
+					|| (*pPos >= 'a' && *pPos <='f')
+					|| (*pPos >= 'A' && *pPos <= 'F')))
+			{
+			if (u64Int <= 0x0FFF'FFFF'FFFF'FFFF || bAllowOverflow)
+				{
+				if (u64Int > 0x0FFF'FFFF'FFFF'FFFF && retbOverflowed)
+					*retbOverflowed = true;
+
+				u64Int <<= 4;
+
+				if (*pPos >= '0' && *pPos <= '9')
+					u64Int += (*pPos - '0');
+				else if (*pPos >= 'A' && *pPos <= 'F')
+					u64Int += (10 + (*pPos - 'A'));
+				else
+					u64Int += (10 + (*pPos - 'a'));
+				}
+
+			//	If we overflowed and dont allow overflow
+			//	we cap to tha maximum unsigned int
+
+			else
+				{
+				u64Int = 0xFFFF'FFFF'FFFF'FFFF;
+				if (retbOverflowed)
+					*retbOverflowed = true;
+				}
+
+			pPos++;
+			}
+		}
+	else
+		{
+		while (*pPos != '\0' && *pPos >= '0' && *pPos <= '9')
+			{
+			bFoundNumber = TRUE;
+			if (u64Int < 0x1999'9999'9999'9999 || (u64Int == 0x1999'9999'9999'9999 && *pPos <= '5'))
+				u64Int = 10 * u64Int + (*pPos - '0');
+			else if (bAllowOverflow)
+				{
+				u64Int = 10 * u64Int + (*pPos - '0');
+				if (retbOverflowed)
+					*retbOverflowed = true;
+				}
+			else
+				{
+				u64Int = 0xFFFF'FFFF'FFFF'FFFF;
+				if (retbOverflowed)
+					*retbOverflowed = true;
+				}
+			pPos++;
+
+			if (bExpectSeparators && *pPos == ',')
+				pPos++;
+			}
+		}
+
+	//	Done?
+
+	if (!bFoundNumber)
+		{
+		if (retbNullValue)
+			*retbNullValue = true;
+
+		if (retpEnd)
+			*retpEnd = pPos;
+
+		return u64NullResult;
+		}
+
+	//	Done!
+
+	if (retbNegativeCharDetected)
+		*retbNegativeCharDetected = bNegative;
+
+	if (retpEnd)
+		*retpEnd = pPos;
+
+	return u64Int;
+	}
+
+//	strParseUInt64
+//
+//	pStart: Start parsing. Skips any leading whitespace
+//	iNullResult: If there are no valid numbers, returns this value
+//	retpEnd: Returns the character at which we stopped parsing
+//	retbNullValue: Returns TRUE if there are no valid numbers.
+// 	retbNegativeChatDetected: Returns TRUE if a '-' was detected immediately preceding the number.
+// 
+// 	Flags:
+// 	   PARSE_ALLOW_OVERFLOWL: continue shifting bits after exceeding 0xFFFF'FFFF'FFFF'FFFF
+// 	   PARSE_THOUSAND_SEPARATOR: allow
+//
+INT64 Kernel::strParseInt64 (
+	const char *pStart,
+	INT64 i64NullResult,
+	UINT32 uFlags,
+	const char **retpEnd,
+	bool *retbNullValue,
+	bool *retbOverflowed,
+	bool *retbNegativeCharDetected)
+	{
+	bool bInnerNullValue = false;
+	bool bInnerOverflow = false;
+	bool bNegativeChar = false;
+
+	if (retbNullValue)
+		*retbNullValue = false;
+	if (retbOverflowed)
+		*retbOverflowed = false;
+	if (retbNegativeCharDetected)
+		*retbNegativeCharDetected = false;
+
+	bool bAllowOverflow = uFlags & PARSE_ALLOW_OVERFLOW;
+
+	UINT64 u64Raw = strParseUInt64(pStart, 0, uFlags, retpEnd, &bInnerNullValue, &bInnerOverflow, &bNegativeChar);
+
+	//	If we were null, we continue
+
+	if (bInnerNullValue)
+		{
+		if (retbNullValue)
+			*retbNullValue = true;
+		return i64NullResult;
+		}
+
+	//	Set overflow bool as appropriate for a signed int64
+
+	bool bOverflowed = bInnerOverflow || u64Raw > 0x7FFF'FFFF'FFFF'FFFF;
+
+	if (retbOverflowed)
+		*retbOverflowed = bOverflowed;
+
+	//	Handle truncation and sign as necessary
+
+	if (bOverflowed && !bAllowOverflow)
+		u64Raw = 0x7FFF'FFFF'FFFF'FFFF;
+
+	INT64 i64Int = (INT64)u64Raw;
+
+	if (bNegativeChar)
+		{
+		i64Int *= -1;
+		if (retbNegativeCharDetected)
+			*retbNegativeCharDetected = true;
+		}
+
+	//	done
+
+	return i64Int;
+	}
+
+//	strParseInt32
+//
+//	pStart: Start parsing. Skips any leading whitespace
+//	iNullResult: If there are no valid numbers, returns this value
+//	retpEnd: Returns the character at which we stopped parsing
+//	retbNullValue: Returns TRUE if there are no valid numbers.
+// 	retbNegativeChatDetected: Returns TRUE if a '-' was detected immediately preceding the number.
+// 
+// 	Flags:
+// 	   PARSE_ALLOW_OVERFLOWL: continue shifting bits after exceeding 0xFFFF'FFFF'FFFF'FFFF
+// 	   PARSE_THOUSAND_SEPARATOR: allow
+//
+INT32 Kernel::strParseInt32 (
+	const char *pStart,
+	INT32 iNullResult,
+	UINT32 uFlags,
+	const char **retpEnd,
+	bool *retbNullValue,
+	bool *retbOverflowed,
+	bool *retbNegativeCharDetected)
+	{
+	bool bInnerNullValue = false;
+	bool bInnerOverflow = false;
+	bool bNegativeChar = false;
+
+	if (retbNullValue)
+		*retbNullValue = false;
+	if (retbOverflowed)
+		*retbOverflowed = false;
+	if (retbNegativeCharDetected)
+		*retbNegativeCharDetected = false;
+
+	bool bAllowOverflow = uFlags & PARSE_ALLOW_OVERFLOW;
+
+	UINT64 u64Raw = strParseUInt64(pStart, 0, uFlags, retpEnd, &bInnerNullValue, &bInnerOverflow, &bNegativeChar);
+
+	//	If we were null, we continue
+
+	if (bInnerNullValue)
+		{
+		if (retbNullValue)
+			*retbNullValue = true;
+		return iNullResult;
+		}
+
+	//	Set overflow bool as appropriate for a signed int32
+
+	bool bOverflowed = bInnerOverflow || u64Raw > 0x7FFF'FFFF;
+
+	if (retbOverflowed)
+		*retbOverflowed = bOverflowed;
+
+	//	Handle truncation and sign as necessary
+
+	if (bOverflowed && !bAllowOverflow)
+		u64Raw = 0x7FFF'FFFF;
+
+	int iInt = (int)u64Raw;
+
+	if (bNegativeChar)
+		{
+		iInt *= -1;
+		if (retbNegativeCharDetected)
+			*retbNegativeCharDetected = true;
+		}
+
+	//	done
+
+	return iInt;
+	}
+
+//	strParseUInt32
+//
+//	pStart: Start parsing. Skips any leading whitespace
+//	iNullResult: If there are no valid numbers, returns this value
+//	retpEnd: Returns the character at which we stopped parsing
+//	retbNullValue: Returns TRUE if there are no valid numbers.
+// 	retbNegativeChatDetected: Returns TRUE if a '-' was detected immediately preceding the number.
+// 
+// 	Flags:
+// 	   PARSE_ALLOW_OVERFLOWL: continue shifting bits after exceeding 0xFFFF'FFFF'FFFF'FFFF
+// 	   PARSE_THOUSAND_SEPARATOR: allow
+//
+UINT32 Kernel::strParseUInt32 (
+	const char *pStart,
+	UINT32 uNullResult,
+	UINT32 uFlags,
+	const char **retpEnd,
+	bool *retbNullValue,
+	bool *retbOverflowed,
+	bool *retbNegativeCharDetected)
+	{
+	bool bInnerNullValue = false;
+	bool bInnerOverflow = false;
+
+	if (retbNullValue)
+		*retbNullValue = false;
+	if (retbOverflowed)
+		*retbOverflowed = false;
+
+	bool bAllowOverflow = uFlags & PARSE_ALLOW_OVERFLOW;
+
+	UINT64 u64Raw = strParseUInt64(pStart, 0, uFlags, retpEnd, &bInnerNullValue, &bInnerOverflow, retbNegativeCharDetected);
+
+	//	If we were null, we continue
+
+	if (bInnerNullValue)
+		{
+		if (retbNullValue)
+			*retbNullValue = true;
+		return uNullResult;
+		}
+
+	//	Set overflow bool as appropriate for a signed int32
+
+	bool bOverflowed = bInnerOverflow || u64Raw > 0xFFFF'FFFF;
+
+	if (retbOverflowed)
+		*retbOverflowed = bOverflowed;
+
+	//	Handle truncation and sign as necessary
+
+	if (bOverflowed && !bAllowOverflow)
+		u64Raw = 0xFFFF'FFFF;
+
+	UINT32 uInt = (UINT32)u64Raw;
+
+	//	done
+
+	return uInt;
+	}
+
+//	strParseInt
+// 
+//	DEPRECATED - use strParseInt32 or strParseUInt32 instead
+//
+//	pStart: Start parsing. Skips any leading whitespace
+//	iNullResult: If there are no valid numbers, returns this value
+//	retpEnd: Returns the character at which we stopped parsing
+//	retbNullValue: Returns TRUE if there are no valid numbers.
+// 
+// 	Flags:
+// 	   PARSE_ALLOW_OVERFLOWL: continue shifting bits after exceeding 0xFFFFFFFF
+//			Note - even if not set, may overflow to a negative number. This is intended for supporting UNID/DWORD loading.
+// 	   PARSE_THOUSAND_SEPARATOR: allow
+//
+int Kernel::strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, const char **retpEnd, bool *retbNullValue)
+
+	{
+	const char *pPos = pStart;
+	BOOL bNegative = false;
+	BOOL bFoundNumber = false;
+	BOOL bHex = false;
+	DWORD dwInt = 0;
+
+	//	Parse flags
+
+	bool bExpectSeparators = dwFlags & PARSE_THOUSAND_SEPARATOR;
+	bool bAllowOverflow = dwFlags & PARSE_ALLOW_OVERFLOW;
+
+	//	Preset
+
+	if (retbNullValue)
+		*retbNullValue = false;
 
 	//	Skip whitespace
 
@@ -2540,25 +2922,37 @@ int Kernel::strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, con
 					|| (*pPos >= 'a' && *pPos <='f')
 					|| (*pPos >= 'A' && *pPos <= 'F')))
 			{
-			if (*pPos >= '0' && *pPos <= '9')
-				dwInt = 16 * dwInt + (*pPos - '0');
-			else if (*pPos >= 'A' && *pPos <= 'F')
-				dwInt = 16 * dwInt + (10 + (*pPos - 'A'));
+			if (dwInt < 0x0FFFFFFF || bAllowOverflow)
+				{
+				dwInt *= 16;
+
+				if (*pPos >= '0' && *pPos <= '9')
+					dwInt += (*pPos - '0');
+				else if (*pPos >= 'A' && *pPos <= 'F')
+					dwInt += (10 + (*pPos - 'A'));
+				else
+					dwInt += (10 + (*pPos - 'a'));
+				}
+
+			//	If we overflowed and dont allow overflow
+			//	we cap to tha maximum unsigned int
+
 			else
-				dwInt = 16 * dwInt + (10 + (*pPos - 'a'));
+				dwInt = 0xFFFFFFFF;
 
 			pPos++;
 			}
-
-		iInt = (int)dwInt;
 		}
 	else
 		{
 		while (*pPos != '\0' && *pPos >= '0' && *pPos <= '9')
 			{
-			iInt = 10 * iInt + (*pPos - '0');
-			pPos++;
 			bFoundNumber = TRUE;
+			if (dwInt < 0x19999999 || (dwInt == 0x19999999 && *pPos <= '5') || bAllowOverflow)
+				dwInt = 10 * dwInt + (*pPos - '0');
+			else
+				dwInt = 0xFFFFFFFF;
+			pPos++;
 
 			if (bExpectSeparators && *pPos == ',')
 				pPos++;
@@ -2579,6 +2973,7 @@ int Kernel::strParseInt (const char *pStart, int iNullResult, DWORD dwFlags, con
 		}
 
 	//	Done!
+	int iInt = (int)dwInt;
 
 	if (bNegative)
 		iInt = -iInt;

--- a/Alchemy/XMLUtil/CXMLElement.cpp
+++ b/Alchemy/XMLUtil/CXMLElement.cpp
@@ -390,17 +390,9 @@ double CXMLElement::GetAttributeFloat (const CString &sName) const
 	return strToDouble(GetAttribute(sName), 0.0);
 	}
 
-//	GetAttributeInteger
-//
-//	Returns an integer attribute
-//
-int CXMLElement::GetAttributeInteger (const CString &sName) const
-
-	{
-	return strToInt(GetAttribute(sName), 0, NULL);
-	}
-
 //	GetAttributeIntegerDefault
+// 
+//	DEPRECATED: use GetAttributeInt32/64Default or GetAttributeUInt32/64Default
 //
 //	Returns an integer attribute
 //  Return iNull if not found
@@ -423,6 +415,8 @@ int CXMLElement::GetAttributeIntegerDefault (const CString &sName, int iNull) co
 	}
 
 //	GetAttributeIntegerBounded
+// 
+//	DEPRECATED: use GetAttributeInt32/64Bounded or GetAttributeUInt32/64Bounded
 //
 //	Returns an integer, insuring that it is in range
 //
@@ -456,32 +450,14 @@ int CXMLElement::GetAttributeIntegerBounded (const CString &sName, int iMin, int
 		return iNull;
 	}
 
-ALERROR CXMLElement::GetAttributeIntegerList (const CString &sName, TArray<int> *pList) const
-
-//	GetAttributeIntegerList
-//
-//	Appends a list of integers separated by commas
-
-	{
-	return ParseAttributeIntegerList(GetAttribute(sName), pList);
-	}
-
-ALERROR CXMLElement::GetAttributeIntegerList (const CString &sName, TArray<DWORD> *pList) const
-
-//	GetAttributeIntegerList
-//
-//	Appends a list of integers separated by commas
-
-	{
-	return ParseAttributeIntegerList(GetAttribute(sName), pList);
-	}
-
-bool CXMLElement::GetAttributeIntegerRange (const CString &sName, int *retiLow, int *retiHigh, int iMin, int iMax, int iNullLow, int iNullHigh, bool bAllowInverted) const
-
 //  GetAttributeIntegerRange
+// 
+//	DEPRECATED: use GetAttributeInt32/64Range or GetAttributeUInt32/64Range
 //
 //  Parses two numbers separated by a hyphen. We return TRUE if we have a range.
 //  Otherwise, we return FALSE and retiLow is the number.
+//
+bool CXMLElement::GetAttributeIntegerRange (const CString &sName, int *retiLow, int *retiHigh, int iMin, int iMax, int iNullLow, int iNullHigh, bool bAllowInverted) const
 
     {
 	CString sValue;
@@ -553,6 +529,558 @@ bool CXMLElement::GetAttributeIntegerRange (const CString &sName, int *retiLow, 
     *retiHigh = iHigh;
     return (iLow != iHigh);
     }
+
+//	GetAttributeInt32Default
+//
+//	Returns an integer attribute (Truncates overflow)
+//  Return iNull if not found
+//
+int CXMLElement::GetAttributeInt32Default (const CString &sName, int iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		int iValue = strToInt32(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+		else
+			return iValue;
+		}
+	else
+		return iNull;
+	}
+
+//	GetAttributeInt32Bounded
+//
+//	Returns an integer, insuring that it is in range
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+int CXMLElement::GetAttributeInt32Bounded (const CString &sName, int iMin, int iMax, int iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		int iValue = strToInt32(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+
+		//	The null value is always valid
+
+		if (iValue == iNull)
+			return iValue;
+
+		//	If iMax is less than iMin, then there is no maximum
+
+		else if (iMax < iMin)
+			return Max(iValue, iMin);
+
+		//	Bounded
+
+		else
+			return Max(Min(iValue, iMax), iMin);
+		}
+	else
+		return iNull;
+	}
+
+//  GetAttributeInt32Range
+//
+//  Parses two numbers separated by a hyphen. We return TRUE if we have a range.
+//  Otherwise, we return FALSE and retiLow is the number.
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+bool CXMLElement::GetAttributeInt32Range (const CString &sName, int *retiLow, int *retiHigh, int iMin, int iMax, int iNullLow, int iNullHigh, bool bAllowInverted) const
+
+    {
+	CString sValue;
+    if (!FindAttribute(sName, &sValue))
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Parse the first number
+
+    const char *pPos = sValue.GetASCIIZPointer();
+    bool bNullValue;
+	int iValue = strParseInt32(pPos, 0, &pPos, &bNullValue);
+    if (bNullValue)
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Make sure we're in range
+
+    int iLow;
+    if (iValue == iNullLow)
+        iLow = iValue;
+    else if (iMax < iMin)
+        iLow = Max(iMin, iValue);
+    else
+        iLow = Min(Max(iMin, iValue), iMax);
+
+    //  If there is no high value, then we just have a single number
+
+    if (*pPos != '-')
+        {
+        *retiLow = iLow;
+        *retiHigh = iLow;
+        return false;
+        }
+
+    pPos++;
+
+    //  Parse the next number
+
+    int iHigh;
+    iValue = strParseInt32(pPos, 0, &pPos, &bNullValue);
+    if (bNullValue)
+        iHigh = iNullHigh;
+    else if (iValue == iNullHigh)
+        iHigh = iValue;
+    else if (iMax < iMin)
+        iHigh = Max(iMin, iValue);
+    else
+        iHigh = Min(Max(iMin, iValue), iMax);
+
+    //  If low > high, then we fail, unless we allow an inverted range.
+
+    if (iLow > iHigh && !bAllowInverted)
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Otherwise, we're done
+
+    *retiLow = iLow;
+    *retiHigh = iHigh;
+    return (iLow != iHigh);
+    }
+
+//	GetAttributeInt32Default
+//
+//	Returns an integer attribute (Truncates overflow)
+//  Return iNull if not found
+//
+UINT32 CXMLElement::GetAttributeUInt32Default(const CString& sName, UINT32 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		UINT32 iValue = strToUInt32(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+		else
+			return iValue;
+		}
+	else
+		return iNull;
+	}
+
+//	GetAttributeInt32Bounded
+//
+//	Returns an integer, insuring that it is in range
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+UINT32 CXMLElement::GetAttributeUInt32Bounded(const CString& sName, UINT32 iMin, UINT32 iMax, UINT32 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		UINT32 iValue = strToUInt32(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+
+		//	The null value is always valid
+
+		if (iValue == iNull)
+			return iValue;
+
+		//	If iMax is less than iMin, then there is no maximum
+
+		else if (iMax < iMin)
+			return Max(iValue, iMin);
+
+		//	Bounded
+
+		else
+			return Max(Min(iValue, iMax), iMin);
+		}
+	else
+		return iNull;
+	}
+
+//  GetAttributeUInt32Range
+//
+//  Parses two numbers separated by a hyphen. We return TRUE if we have a range.
+//  Otherwise, we return FALSE and retiLow is the number.
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+bool CXMLElement::GetAttributeUInt32Range(const CString& sName, UINT32* retuLow, UINT32* retuHigh, UINT32 uMin, UINT32 uMax, UINT32 uNullLow, UINT32 uNullHigh, bool bAllowInverted) const
+
+	{
+	CString sValue;
+	if (!FindAttribute(sName, &sValue))
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Parse the first number
+
+	const char* pPos = sValue.GetASCIIZPointer();
+	bool bNullValue;
+	UINT32 iValue = strParseUInt32(pPos, 0, &pPos, &bNullValue);
+	if (bNullValue)
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Make sure we're in range
+
+	UINT32 uLow;
+	if (iValue == uNullLow)
+		uLow = iValue;
+	else if (uMax < uMin)
+		uLow = Max(uMin, iValue);
+	else
+		uLow = Min(Max(uMin, iValue), uMax);
+
+	//  If there is no high value, then we just have a single number
+
+	if (*pPos != '-')
+		{
+		*retuLow = uLow;
+		*retuHigh = uLow;
+		return false;
+		}
+
+	pPos++;
+
+	//  Parse the next number
+
+	UINT32 uHigh;
+	iValue = strParseUInt32(pPos, 0, &pPos, &bNullValue);
+	if (bNullValue)
+		uHigh = uNullHigh;
+	else if (iValue == uNullHigh)
+		uHigh = iValue;
+	else if (uMax < uMin)
+		uHigh = Max(uMin, iValue);
+	else
+		uHigh = Min(Max(uMin, iValue), uMax);
+
+	//  If low > high, then we fail, unless we allow an inverted range.
+
+	if (uLow > uHigh && !bAllowInverted)
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Otherwise, we're done
+
+	*retuLow = uLow;
+	*retuHigh = uHigh;
+	return (uLow != uHigh);
+	}
+
+//	GetAttributeInt64Default
+//
+//	Returns an integer attribute (Truncates overflow)
+//  Return iNull if not found
+//
+INT64 CXMLElement::GetAttributeInt64Default (const CString &sName, INT64 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		INT64 iValue = strToInt64(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+		else
+			return iValue;
+		}
+	else
+		return iNull;
+	}
+
+//	GetAttributeInt64Bounded
+//
+//	Returns an integer, insuring that it is in range
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+INT64 CXMLElement::GetAttributeInt64Bounded (const CString &sName, INT64 iMin, INT64 iMax, INT64 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		INT64 iValue = strToInt64(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+
+		//	The null value is always valid
+
+		if (iValue == iNull)
+			return iValue;
+
+		//	If iMax is less than iMin, then there is no maximum
+
+		else if (iMax < iMin)
+			return Max(iValue, iMin);
+
+		//	Bounded
+
+		else
+			return Max(Min(iValue, iMax), iMin);
+		}
+	else
+		return iNull;
+	}
+
+//  GetAttributeInt64Range
+//
+//  Parses two numbers separated by a hyphen. We return TRUE if we have a range.
+//  Otherwise, we return FALSE and retiLow is the number.
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+bool CXMLElement::GetAttributeInt64Range (const CString &sName, INT64 *retiLow, INT64 *retiHigh, INT64 iMin, INT64 iMax, INT64 iNullLow, INT64 iNullHigh, bool bAllowInverted) const
+
+    {
+	CString sValue;
+    if (!FindAttribute(sName, &sValue))
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Parse the first number
+
+    const char *pPos = sValue.GetASCIIZPointer();
+    bool bNullValue;
+	INT64 iValue = strParseInt64(pPos, 0, &pPos, &bNullValue);
+    if (bNullValue)
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Make sure we're in range
+
+    int iLow;
+    if (iValue == iNullLow)
+        iLow = iValue;
+    else if (iMax < iMin)
+        iLow = Max(iMin, iValue);
+    else
+        iLow = Min(Max(iMin, iValue), iMax);
+
+    //  If there is no high value, then we just have a single number
+
+    if (*pPos != '-')
+        {
+        *retiLow = iLow;
+        *retiHigh = iLow;
+        return false;
+        }
+
+    pPos++;
+
+    //  Parse the next number
+
+    int iHigh;
+    iValue = strParseInt64(pPos, 0, &pPos, &bNullValue);
+    if (bNullValue)
+        iHigh = iNullHigh;
+    else if (iValue == iNullHigh)
+        iHigh = iValue;
+    else if (iMax < iMin)
+        iHigh = Max(iMin, iValue);
+    else
+        iHigh = Min(Max(iMin, iValue), iMax);
+
+    //  If low > high, then we fail, unless we allow an inverted range.
+
+    if (iLow > iHigh && !bAllowInverted)
+        {
+        *retiLow = iNullLow;
+        *retiHigh = iNullHigh;
+        return (iNullLow != iNullHigh);
+        }
+
+    //  Otherwise, we're done
+
+    *retiLow = iLow;
+    *retiHigh = iHigh;
+    return (iLow != iHigh);
+    }
+
+//	GetAttributeInt64Default
+//
+//	Returns an integer attribute (Truncates overflow)
+//  Return iNull if not found
+//
+UINT64 CXMLElement::GetAttributeUInt64Default(const CString& sName, UINT64 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		UINT64 iValue = strToUInt64(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+		else
+			return iValue;
+		}
+	else
+		return iNull;
+	}
+
+//	GetAttributeInt64Bounded
+//
+//	Returns an integer, insuring that it is in range
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+UINT64 CXMLElement::GetAttributeUInt64Bounded(const CString& sName, UINT64 iMin, UINT64 iMax, UINT64 iNull) const
+
+	{
+	CString sValue;
+	if (FindAttribute(sName, &sValue))
+		{
+		bool bFailed;
+		UINT64 uValue = strToUInt64(sValue, iNull, &bFailed);
+		if (bFailed)
+			return iNull;
+
+		//	The null value is always valid
+
+		if (uValue == iNull)
+			return uValue;
+
+		//	If iMax is less than iMin, then there is no maximum
+
+		else if (iMax < iMin)
+			return Max(uValue, iMin);
+
+		//	Bounded
+
+		else
+			return Max(Min(uValue, iMax), iMin);
+		}
+	else
+		return iNull;
+	}
+
+//  GetAttributeUInt64Range
+//
+//  Parses two numbers separated by a hyphen. We return TRUE if we have a range.
+//  Otherwise, we return FALSE and retiLow is the number.
+//		Truncates overflow is iMax is unbounded
+//		iMin is never unbounded
+//
+bool CXMLElement::GetAttributeUInt64Range(const CString& sName, UINT64* retuLow, UINT64* retuHigh, UINT64 uMin, UINT64 uMax, UINT64 uNullLow, UINT64 uNullHigh, bool bAllowInverted) const
+
+	{
+	CString sValue;
+	if (!FindAttribute(sName, &sValue))
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Parse the first number
+
+	const char* pPos = sValue.GetASCIIZPointer();
+	bool bNullValue;
+	UINT64 uValue = strParseUInt64(pPos, 0, &pPos, &bNullValue);
+	if (bNullValue)
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Make sure we're in range
+
+	UINT64 uLow;
+	if (uValue == uNullLow)
+		uLow = uValue;
+	else if (uMax < uMin)
+		uLow = Max(uMin, uValue);
+	else
+		uLow = Min(Max(uMin, uValue), uMax);
+
+	//  If there is no high value, then we just have a single number
+
+	if (*pPos != '-')
+		{
+		*retuLow = uLow;
+		*retuHigh = uLow;
+		return false;
+		}
+
+	pPos++;
+
+	//  Parse the next number
+
+	UINT64 uHigh;
+	uValue = strParseUInt64(pPos, 0, &pPos, &bNullValue);
+	if (bNullValue)
+		uHigh = uNullHigh;
+	else if (uValue == uNullHigh)
+		uHigh = uValue;
+	else if (uMax < uMin)
+		uHigh = Max(uMin, uValue);
+	else
+		uHigh = Min(Max(uMin, uValue), uMax);
+
+	//  If low > high, then we fail, unless we allow an inverted range.
+
+	if (uLow > uHigh && !bAllowInverted)
+		{
+		*retuLow = uNullLow;
+		*retuHigh = uNullHigh;
+		return (uNullLow != uNullHigh);
+		}
+
+	//  Otherwise, we're done
+
+	*retuLow = uLow;
+	*retuHigh = uHigh;
+	return (uLow != uHigh);
+	}
 
 int CXMLElement::GetAttributeTriState (const CString &sName) const
 

--- a/Alchemy/XMLUtil/CXMLElement.cpp
+++ b/Alchemy/XMLUtil/CXMLElement.cpp
@@ -265,12 +265,14 @@ bool CXMLElement::FindAttributeDouble (const CString &sName, double *retrValue) 
 	return true;
 	}
 
-bool CXMLElement::FindAttributeInteger (const CString &sName, int *retiValue) const
-
 //	FindAttributeInteger
 //
+//	Deprecated: use FindAttributeInt32/FindAttributeUInt32 instead
+// 
 //	If the attribute exists, returns TRUE and the attribute value.
 //	Otherwise, returns FALSE
+//
+bool CXMLElement::FindAttributeInteger (const CString &sName, int *retiValue) const
 
 	{
 	const CString *pValue = m_Attributes.GetAt(m_Keywords.Atomize(sName));
@@ -279,6 +281,74 @@ bool CXMLElement::FindAttributeInteger (const CString &sName, int *retiValue) co
 
 	if (retiValue)
 		*retiValue = strToInt(*pValue, 0, NULL);
+	return true;
+	}
+
+//	FindAttributeInt32
+// 
+//	If the attribute exists, returns TRUE and the attribute value.
+//	Otherwise, returns FALSE
+//
+bool CXMLElement::FindAttributeInt32 (const CString &sName, int* retiValue) const
+
+	{
+	const CString *pValue = m_Attributes.GetAt(m_Keywords.Atomize(sName));
+	if (pValue == NULL)
+		return false;
+
+	if (retiValue)
+		*retiValue = strToInt32(*pValue, 0, NULL);
+	return true;
+	}
+
+//	FindAttributeUInt32
+// 
+//	If the attribute exists, returns TRUE and the attribute value.
+//	Otherwise, returns FALSE
+//
+bool CXMLElement::FindAttributeUInt32 (const CString &sName, UINT32* retiValue) const
+
+	{
+	const CString *pValue = m_Attributes.GetAt(m_Keywords.Atomize(sName));
+	if (pValue == NULL)
+		return false;
+
+	if (retiValue)
+		*retiValue = strToUInt32(*pValue, 0, NULL);
+	return true;
+	}
+
+//	FindAttributeInt64
+// 
+//	If the attribute exists, returns TRUE and the attribute value.
+//	Otherwise, returns FALSE
+//
+bool CXMLElement::FindAttributeInt64(const CString& sName, INT64* retiValue) const
+
+	{
+	const CString* pValue = m_Attributes.GetAt(m_Keywords.Atomize(sName));
+	if (pValue == NULL)
+		return false;
+
+	if (retiValue)
+		*retiValue = strToInt64(*pValue, 0, NULL);
+	return true;
+	}
+
+//	FindAttributeUInt64
+// 
+//	If the attribute exists, returns TRUE and the attribute value.
+//	Otherwise, returns FALSE
+//
+bool CXMLElement::FindAttributeUInt64 (const CString &sName, UINT64* retiValue) const
+
+	{
+	const CString *pValue = m_Attributes.GetAt(m_Keywords.Atomize(sName));
+	if (pValue == NULL)
+		return false;
+
+	if (retiValue)
+		*retiValue = strToUInt64(*pValue, 0, NULL);
 	return true;
 	}
 

--- a/Alchemy/XMLUtil/CXMLElement.cpp
+++ b/Alchemy/XMLUtil/CXMLElement.cpp
@@ -896,7 +896,7 @@ bool CXMLElement::GetAttributeInt64Range (const CString &sName, INT64 *retiLow, 
 
     //  Make sure we're in range
 
-    int iLow;
+    INT64 iLow;
     if (iValue == iNullLow)
         iLow = iValue;
     else if (iMax < iMin)
@@ -917,7 +917,7 @@ bool CXMLElement::GetAttributeInt64Range (const CString &sName, INT64 *retiLow, 
 
     //  Parse the next number
 
-    int iHigh;
+    INT64 iHigh;
     iValue = strParseInt64(pPos, 0, &pPos, &bNullValue);
     if (bNullValue)
         iHigh = iNullHigh;
@@ -1081,6 +1081,42 @@ bool CXMLElement::GetAttributeUInt64Range(const CString& sName, UINT64* retuLow,
 	*retuHigh = uHigh;
 	return (uLow != uHigh);
 	}
+
+//	GetAttributeIntegerList
+// 
+//	Appends a list of integers separated by commas
+//
+ALERROR CXMLElement::GetAttributeIntegerList(const CString& sName, TArray<int>* pList) const
+	{
+	return ParseAttributeIntegerList(GetAttribute(sName), pList);
+	}
+
+//	GetAttributeIntegerList
+// 
+//	Appends a list of integers separated by commas
+//
+ALERROR CXMLElement::GetAttributeIntegerList(const CString& sName, TArray<DWORD>* pList) const
+{
+	return ParseAttributeIntegerList(GetAttribute(sName), pList);
+}
+
+//	GetAttributeIntegerList
+// 
+//	Appends a list of integers separated by commas
+//
+ALERROR CXMLElement::GetAttributeIntegerList(const CString& sName, TArray<INT64>* pList) const
+{
+	return ParseAttributeIntegerList(GetAttribute(sName), pList);
+}
+
+//	GetAttributeIntegerList
+// 
+//	Appends a list of integers separated by commas
+//
+ALERROR CXMLElement::GetAttributeIntegerList(const CString& sName, TArray<UINT64>* pList) const
+{
+	return ParseAttributeIntegerList(GetAttribute(sName), pList);
+}
 
 int CXMLElement::GetAttributeTriState (const CString &sName) const
 

--- a/Alchemy/XMLUtil/Misc.cpp
+++ b/Alchemy/XMLUtil/Misc.cpp
@@ -271,11 +271,11 @@ ALERROR CreateXMLElementFromCommandLine (int argc, const char *argv[], CXMLEleme
 	return NOERROR;
 	}
 
-ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<int> *pList)
-
 //	ParseAttributeIntegerList
 //
 //	Parses a string into an integer list
+//
+ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<int> *pList)
 
 	{
 	const char *pPos = sValue.GetPointer();
@@ -292,8 +292,7 @@ ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<int> *pList)
 		if (*pPos != '\0')
 			{
 			bool bNull;
-			int iInt;
-			iInt = strParseInt(pPos, 0, &pPos, &bNull);
+			int iInt = strParseInt32(pPos, 0, &pPos, &bNull);
 
 			//	If we have a valid integer then add it
 
@@ -307,11 +306,11 @@ ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<int> *pList)
 	return NOERROR;
 	}
 
-ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<DWORD> *pList)
-
 //	ParseAttributeIntegerList
 //
 //	Parses a string into an integer list
+//
+ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<DWORD> *pList)
 
 	{
 	const char *pPos = sValue.GetPointer();
@@ -328,8 +327,77 @@ ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<DWORD> *pList)
 		if (*pPos != '\0')
 			{
 			bool bNull;
-			DWORD dwInt;
-			dwInt = (DWORD)strParseInt(pPos, 0, &pPos, &bNull);
+			DWORD dwInt = strParseInt32(pPos, 0, &pPos, &bNull);
+
+			//	If we have a valid integer then add it
+
+			if (!bNull)
+				pList->Insert(dwInt);
+			else
+				break;
+			}
+		}
+
+	return NOERROR;
+	}
+
+//	ParseAttributeIntegerList
+//
+//	Parses a string into an integer list
+//
+ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<INT64> *pList)
+
+	{
+	const char *pPos = sValue.GetPointer();
+
+	while (*pPos != '\0')
+		{
+		//	Skip non-numbers
+
+		while (*pPos != '\0' && (*pPos < '0' || *pPos > '9') && *pPos != '-' && *pPos != '+')
+			pPos++;
+
+		//	Parse an integer
+
+		if (*pPos != '\0')
+			{
+			bool bNull;
+			INT64 iInt = strParseInt64(pPos, 0, &pPos, &bNull);
+
+			//	If we have a valid integer then add it
+
+			if (!bNull)
+				pList->Insert(iInt);
+			else
+				break;
+			}
+		}
+
+	return NOERROR;
+	}
+
+//	ParseAttributeIntegerList
+//
+//	Parses a string into an integer list
+//
+ALERROR ParseAttributeIntegerList (const CString &sValue, TArray<UINT64> *pList)
+
+	{
+	const char *pPos = sValue.GetPointer();
+
+	while (*pPos != '\0')
+		{
+		//	Skip non-numbers
+
+		while (*pPos != '\0' && (*pPos < '0' || *pPos > '9') && *pPos != '-' && *pPos != '+')
+			pPos++;
+
+		//	Parse an integer
+
+		if (*pPos != '\0')
+			{
+			bool bNull;
+			UINT64 dwInt = strParseInt64(pPos, 0, &pPos, &bNull);
 
 			//	If we have a valid integer then add it
 

--- a/Mammoth/TSE/CEconomyType.cpp
+++ b/Mammoth/TSE/CEconomyType.cpp
@@ -401,7 +401,7 @@ ALERROR CCurrencyValueDesc::Parse (SDesignLoadCtx &Ctx, const CString &sDesc, co
 	if ((*pPos == '+' || *pPos == '-') && !Default.IsEmpty())
 		{
 		bool bFailed;
-		int iBonus = strToInt(sDesc, 0, &bFailed);
+		int iBonus = strToInt32(sDesc, 0, &bFailed);
 		if (bFailed || iBonus < -100)
 			{
 			Ctx.sError = strPatternSubst(CONSTLIT("Invalid currency adjustment: %s"), sDesc);
@@ -564,7 +564,7 @@ ALERROR CCurrencyValueDesc::Parse (SDesignLoadCtx &Ctx, const CString &sDesc, co
 		//	Load the value
 
 		bool bFailed;
-		retValue.SetValue(strToInt(sValue, 0, &bFailed));
+		retValue.SetValue(strToInt64(sValue, 0, &bFailed));
 		if (bFailed)
 			{
 			Ctx.sError = strPatternSubst(CONSTLIT("Invalid currency value: %s"), sValue);

--- a/Mammoth/TSE/CEffectCreator.cpp
+++ b/Mammoth/TSE/CEffectCreator.cpp
@@ -214,7 +214,7 @@ ALERROR CEffectCreator::CreateFromXML (SDesignLoadCtx &Ctx, CXMLElement *pDesc, 
 	CString sEffectUNID = sUNID;
 	if (sEffectUNID.IsBlank())
 		{
-		DWORD dwUNID = pDesc->GetAttributeInteger(UNID_ATTRIB);
+		DWORD dwUNID = pDesc->GetAttributeUInt32(UNID_ATTRIB);
 		if (dwUNID)
 			sEffectUNID = strFromInt(dwUNID, false);
 		else

--- a/Mammoth/TSE/CExtension.cpp
+++ b/Mammoth/TSE/CExtension.cpp
@@ -583,7 +583,7 @@ ALERROR CExtension::CreateExtensionFromRoot (const CString &sFilespec, CXMLEleme
 
 	CExtension *pExtension = new CExtension;
 	pExtension->m_sFilespec = sFilespec;
-	pExtension->m_dwUNID = pDesc->GetAttributeInteger(UNID_ATTRIB);
+	pExtension->m_dwUNID = pDesc->GetAttributeUInt32(UNID_ATTRIB);
 	if (pExtension->m_dwUNID == 0)
 		{
 		delete pExtension;

--- a/Mammoth/TSE/CExtensionCollection.cpp
+++ b/Mammoth/TSE/CExtensionCollection.cpp
@@ -2457,8 +2457,8 @@ ALERROR CLibraryResolver::OnOpenTag (CXMLElement *pElement, CString *retsError)
 	{
 	if (strEquals(pElement->GetTag(), LIBRARY_TAG))
 		{
-		DWORD dwUNID = pElement->GetAttributeInteger(UNID_ATTRIB);
-		DWORD dwRelease = pElement->GetAttributeInteger(RELEASE_ATTRIB);
+		DWORD dwUNID = pElement->GetAttributeUInt32(UNID_ATTRIB);
+		DWORD dwRelease = pElement->GetAttributeUInt32(RELEASE_ATTRIB);
 		bool bOptional = pElement->GetAttributeBool(OPTIONAL_ATTRIB);
 
 		return AddLibrary(dwUNID, dwRelease, bOptional, retsError);

--- a/Mammoth/TSE/CTopologySystemDesc.cpp
+++ b/Mammoth/TSE/CTopologySystemDesc.cpp
@@ -158,7 +158,7 @@ ALERROR CTopologySystemDesc::InitFromXML (SDesignLoadCtx &LoadCtx, CXMLElement *
 
 	//	Initialize from the root element
 
-	m_dwSystemUNID = pDesc->GetAttributeInteger(UNID_ATTRIB);
+	m_dwSystemUNID = pDesc->GetAttributeUInt32(UNID_ATTRIB);
 	m_sName = pDesc->GetAttribute(NAME_ATTRIB);
 	m_iLevel = pDesc->GetAttributeIntegerBounded(LEVEL_ATTRIB, 1, MAX_SYSTEM_LEVEL, 0);
 	m_sAttributes = pDesc->GetAttribute(ATTRIBUTES_ATTRIB);

--- a/Mammoth/TSUI/CExtensionListMap.cpp
+++ b/Mammoth/TSUI/CExtensionListMap.cpp
@@ -106,7 +106,7 @@ ALERROR CExtensionListMap::ReadDefault (CXMLElement *pEntry)
 //	Reads the adventure defaults from XML.
 
 	{
-	DWORD dwAdventure = (DWORD)pEntry->GetAttributeInteger(UNID_ATTRIB);
+	DWORD dwAdventure = (DWORD)pEntry->GetAttributeUInt32(UNID_ATTRIB);
 	bool bDebugMode = pEntry->GetAttributeBool(DEBUG_MODE_ATTRIB);
 
 	SEntry *pNewEntry = m_Map.SetAt(dwAdventure);
@@ -220,7 +220,7 @@ ALERROR CExtensionListMap::ReadOption (CXMLElement *pEntry)
 //	Reads the given XML element as an option.
 
 	{
-	DWORD dwExtension = (DWORD)pEntry->GetAttributeInteger(UNID_ATTRIB);
+	DWORD dwExtension = (DWORD)pEntry->GetAttributeUInt32(UNID_ATTRIB);
 	CString sOption = pEntry->GetAttribute(NAME_ATTRIB);
 	CString sValue = pEntry->GetAttribute(VALUE_ATTRIB);
 

--- a/Transcendence/TransData/EffectPerformanceTest.cpp
+++ b/Transcendence/TransData/EffectPerformanceTest.cpp
@@ -10,7 +10,7 @@
 
 void DoEffectPerformanceTest (CUniverse &Universe, CXMLElement *pCmdLine)
     {
-    DWORD dwEffectUNID = pCmdLine->GetAttributeInteger(UNID_ATTRIB);
+    DWORD dwEffectUNID = pCmdLine->GetAttributeUInt32(UNID_ATTRIB);
     CDesignType *pType = Universe.FindDesignType(dwEffectUNID);
     if (pType == NULL)
         {

--- a/Transcendence/TransWorkshop/CSimpleLibraryResolver.cpp
+++ b/Transcendence/TransWorkshop/CSimpleLibraryResolver.cpp
@@ -44,8 +44,8 @@ ALERROR CSimpleLibraryResolver::OnOpenTag (CXMLElement *pElement, CString *retsE
     {
 	if (strEquals(pElement->GetTag(), LIBRARY_TAG))
 		{
-		DWORD dwUNID = pElement->GetAttributeInteger(UNID_ATTRIB);
-		DWORD dwRelease = pElement->GetAttributeInteger(RELEASE_ATTRIB);
+		DWORD dwUNID = pElement->GetAttributeUInt32(UNID_ATTRIB);
+		DWORD dwRelease = pElement->GetAttributeUInt32(RELEASE_ATTRIB);
 
 		return AddLibrary(dwUNID, retsError);
 		}


### PR DESCRIPTION
…t support and overflow detection/handling. deprecate strParseInt

Note that strParseInt was updated with the new overflow flag too in the interim, despite being deprecated, because theres currently no intended cases where byte-pushing overflow is really meant to be allowed: you either had an invalid UNID anyways, or your value was out of range.