### PR TITLE
fix: 106817: GetNamedDevice should have been used instead of GetDevic…

### DIFF
--- a/Mammoth/TSE/AIManeuvers.cpp
+++ b/Mammoth/TSE/AIManeuvers.cpp
@@ -1813,7 +1813,10 @@ void CAIBehaviorCtx::ImplementFireSingleWeaponOnTarget (CShip* pShip,
 		bool bBestWeaponDamaged = false;
 
 		if (m_iBestWeapon != devNone)
-			bBestWeaponDamaged = pShip->GetDevice(m_iBestWeapon)->IsDamaged();
+			{
+			CInstalledDevice* pBestWeapon = pShip->GetNamedDevice(m_iBestWeapon);
+			bBestWeaponDamaged = pBestWeapon && pBestWeapon->IsDamaged();
+			}
 
 		if (m_iBestWeapon == devNone || (m_fHasSecondaryWeapons && bBestWeaponDamaged))
 			{


### PR DESCRIPTION
…e, since m_iBestWeapon is a named device entry, not the actual device index